### PR TITLE
fix(assets): wrap all hardcoded image paths in assetPath() + promote rule to error

### DIFF
--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -91,6 +91,10 @@ async function checkAssetPathUsage() {
   // or "/videos/x.mp4" that aren't wrapped by assetPath(). We also flag
   // template-literal patterns like `${basePath}/Images/...` since that
   // is the anti-pattern assetPath() exists to replace.
+  //
+  // As of the round-2 cleanup these are ERRORS rather than warnings —
+  // the codebase is clean and any new occurrence is a real bug
+  // (the resource will 404 on GitHub Pages subpath deploys).
   const literalPattern = /(["'`])(\/(?:Images|Svgs|videos)\/[^"'`\n]+?)\1/g
   const templateBasePattern = /\$\{[^}]*basePath[^}]*\}\/(?:Images|Svgs|videos)\//g
   // 400-char lookback covers prettier-wrapped multi-line calls with
@@ -110,7 +114,7 @@ async function checkAssetPathUsage() {
       if (insideComment(body, match.index)) continue
       const lookback = body.slice(Math.max(0, match.index - 400), match.index)
       if (wrappedInAssetPath.test(lookback)) continue
-      warnings.push(
+      errors.push(
         `${rel}:${lineAt(body, match.index)} references "${match[2]}" without assetPath(). ` +
           `Wrap in assetPath('${match[2]}') so it works on GitHub Pages subpaths.`
       )
@@ -119,7 +123,7 @@ async function checkAssetPathUsage() {
     templateBasePattern.lastIndex = 0
     while ((match = templateBasePattern.exec(body))) {
       if (insideComment(body, match.index)) continue
-      warnings.push(
+      errors.push(
         `${rel}:${lineAt(body, match.index)} hand-rolls basePath concatenation ("${match[0]}…"). ` +
           `Use assetPath('/Images/...') instead so the helper stays the single source of truth.`
       )

--- a/src/components/about-us/Card-section/index.tsx
+++ b/src/components/about-us/Card-section/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -33,7 +34,7 @@ const Index = () => {
           {/* Right Image */}
           <div className="w-full md:w-[38.2%] flex justify-center md:justify-start">
             <Image
-              src="/Images/about-us-card-section-image.webp"
+              src={assetPath('/Images/about-us-card-section-image.webp')}
               width={500}
               height={500}
               alt="About Us Card Section Image"

--- a/src/components/domains/Cards-Section/index.tsx
+++ b/src/components/domains/Cards-Section/index.tsx
@@ -1,5 +1,6 @@
 import StepsCard from '@/components/ui/StepContentCard'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 export default function CloudflareSetup() {
   return (
@@ -90,7 +91,7 @@ export default function CloudflareSetup() {
         {/* Screenshot Image – You can change the src */}
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-1.webp" // Change this path
+            src={assetPath('/Images/Card-section-1.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -102,7 +103,7 @@ export default function CloudflareSetup() {
       <StepsCard title="Change your DNS to point to Cloudflare" id="orderstep4">
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-2.webp" // Change this path
+            src={assetPath('/Images/Card-section-2.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -111,7 +112,7 @@ export default function CloudflareSetup() {
         </div>
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-3.webp" // Change this path
+            src={assetPath('/Images/Card-section-3.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -120,7 +121,7 @@ export default function CloudflareSetup() {
         </div>
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-4.webp" // Change this path
+            src={assetPath('/Images/Card-section-4.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}
@@ -129,7 +130,7 @@ export default function CloudflareSetup() {
         </div>
         <div className="mt-10 mb-[34px] -mx-10 md:-mx-15">
           <Image
-            src="/Images/Card-section-5.webp" // Change this path
+            src={assetPath('/Images/Card-section-5.webp')} // Change this path
             alt="User Management - Invite New User"
             width={1200}
             height={800}

--- a/src/components/domains/Curved-Black-Section/index.tsx
+++ b/src/components/domains/Curved-Black-Section/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -11,7 +12,7 @@ const Index = () => {
           {/* Image Section */}
           <div className="relative w-full md:w-[48.5%] h-[350px] mb-[25px] md:mb-0 md:mr-[32px]">
             <Image
-              src="/Images/domains-black-section.webp"
+              src={assetPath('/Images/domains-black-section.webp')}
               alt="domains-blue-section"
               fill
               className="object-contain rounded-[10px]"

--- a/src/components/domains/Curved-Blue-Section/index.tsx
+++ b/src/components/domains/Curved-Blue-Section/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -51,7 +52,7 @@ const Index = () => {
 
         <div className="col-span-2 relative w-full md:w-[48.5%] h-[350px] ">
           <Image
-            src="/Images/domains-blue-section.webp"
+            src={assetPath('/Images/domains-blue-section.webp')}
             alt="domains-blue-section"
             fill
             className="object-contain rounded-[10px]"

--- a/src/components/domains/Hero/index.tsx
+++ b/src/components/domains/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -29,7 +30,7 @@ const Index = () => {
         {/* Right Section */}
         <div className="w-full md:w-[38.2%] flex justify-center md:justify-end">
           <Image
-            src="/Images/Domains-hero.webp"
+            src={assetPath('/Images/Domains-hero.webp')}
             alt="hero image"
             width={500}
             height={400}

--- a/src/components/domains/Setup-Email-Hosting/index.tsx
+++ b/src/components/domains/Setup-Email-Hosting/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -61,7 +62,7 @@ const index = () => {
           {/* Circle Image */}
           <div className="mx-auto flex-shrink-0 w-[100px] h-[100px] overflow-hidden mb-[30px]">
             <Image
-              src="/Images/1.webp"
+              src={assetPath('/Images/1.webp')}
               alt="Step Illustration"
               width={56}
               height={56}
@@ -93,7 +94,7 @@ const index = () => {
           {/* Circle Image */}
           <div className="mx-auto flex-shrink-0 w-[100px] h-[100px] overflow-hidden mb-[30px]">
             <Image
-              src="/Images/2.webp"
+              src={assetPath('/Images/2.webp')}
               alt="Step Illustration"
               width={56}
               height={56}

--- a/src/components/domains/Verify-Your-Domain/index.tsx
+++ b/src/components/domains/Verify-Your-Domain/index.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image'
 import DomainCard from '@/components/ui/Domain-Card'
 import { IoCall } from 'react-icons/io5'
 import { IoMdMail } from 'react-icons/io'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -38,7 +39,7 @@ const index = () => {
             <div className="mb-4 md:mb-0 md:mr-4">
               <div className="relative h-[100px] w-[100px]">
                 <Image
-                  src="/Images/1.webp"
+                  src={assetPath('/Images/1.webp')}
                   fill
                   alt="domain verification email"
                   className="object-contain"
@@ -67,17 +68,17 @@ const index = () => {
 
       <div className="w-[87%] max-w-[1300px] mx-auto py-[22px] grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-[35px] items-stretch">
         <DomainCard
-          imageSrc="/Images/1.webp"
+          imageSrc={assetPath('/Images/1.webp')}
           imageAlt="Email verification icon"
           text="Check for emails about verification to the email address you used to register this domain"
         />
         <DomainCard
-          imageSrc="/Images/2.webp"
+          imageSrc={assetPath('/Images/2.webp')}
           imageAlt="Email verification icon"
           text="FAILING TO RESPOND TO THESE EMAILS WILL RESULT IN SUSPENSION OF YOUR DOMAIN"
         />
         <DomainCard
-          imageSrc="/Images/3.webp"
+          imageSrc={assetPath('/Images/3.webp')}
           imageAlt="Email verification icon"
           text="Free For Charity does not send or control these emails but we will be notified if you did not verify your ownership in the time provided."
         />
@@ -90,7 +91,7 @@ const index = () => {
             <div className="mb-4 md:mb-0 md:mr-4">
               <div className="relative h-[100px] w-[100px]">
                 <Image
-                  src="/Images/2.webp"
+                  src={assetPath('/Images/2.webp')}
                   fill
                   alt="domain verification email"
                   className="object-contain"

--- a/src/components/donate/General-donation/index.tsx
+++ b/src/components/donate/General-donation/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import GeneralDonationCard from '@/components/ui/General-Donation-Card'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -15,19 +16,19 @@ const index = () => {
           <GeneralDonationCard
             title="Monthly Donations"
             description="Monthly donations help by providing a predictable cash flow and are generally put towards expenses that are paid by free for charity each month like hosting and software licenses. By matching up our monthly bills to our monthly donations we can then scale up in tandem to produce more and more for charities."
-            img="/Images/payment.gif"
+            img={assetPath('/Images/payment.gif')}
             href="/donate"
           />
           <GeneralDonationCard
             title="One Time Donations"
             description="On time donations of any amount are placed in the general fund and used to help fund special projects as they become available throughout the year."
-            img="/Images/payment.gif"
+            img={assetPath('/Images/payment.gif')}
             href="/donate"
           />
           <GeneralDonationCard
             title="Large Donations"
             description="For large donations we can work directly with the donor and earmark the funds for a particular project of personal significance. This can be as simple as saying that your donation should be used for the technology programs vs. the business programs or more involved such as that the funds should be used to assist one particular local charity you support"
-            img="/Images/payment.gif"
+            img={assetPath('/Images/payment.gif')}
             href="https://example.com/donate"
           />
         </div>

--- a/src/components/endowment-fund/Empowering-Charities/index.tsx
+++ b/src/components/endowment-fund/Empowering-Charities/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import ProgressBar from '@/components/ui/ProgressBar'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -18,7 +19,7 @@ const Index = () => {
           <div className="w-full md:w-[36.7%] md:mr-[60px] h-auto">
             <div className="relative w-full h-[280px] sm:h-[350px] md:h-[400px]">
               <Image
-                src="/Images/Empowering-Charities.webp"
+                src={assetPath('/Images/Empowering-Charities.webp')}
                 alt="Empowering Charities"
                 fill
                 className="object-cover rounded-[6px]"

--- a/src/components/endowment-fund/Endowment-Features/index.tsx
+++ b/src/components/endowment-fund/Endowment-Features/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import { FaInfoCircle, FaChartPie, FaCreditCard } from 'react-icons/fa'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -11,7 +12,7 @@ const Index = () => {
           <div className="w-full md:w-[47.25%] md:mr-[60px]">
             <div className="relative w-full h-[350px] sm:h-[500px] md:h-[685px]">
               <Image
-                src="/Images/Endowment-Features.webp"
+                src={assetPath('/Images/Endowment-Features.webp')}
                 alt="Endowment Features"
                 fill
                 className="object-cover rounded-[6px] shadow-[0px_40px_112px_-24px_rgba(0,0,0,0.12)]"

--- a/src/components/endowment-fund/Hero/index.tsx
+++ b/src/components/endowment-fund/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -32,7 +33,7 @@ const Index = () => {
         {/* Image Section */}
         <div className="flex justify-center md:justify-start pt-[50px] md:pt-[64px]">
           <img
-            src="/Images/hero-img.webp"
+            src={assetPath('/Images/hero-img.webp')}
             alt="Person signing donation agreement"
             className="w-full max-w-[512px] rounded-[6px] shadow-2xl object-cover"
           />

--- a/src/components/endowment-fund/Our-Mission/index.tsx
+++ b/src/components/endowment-fund/Our-Mission/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -32,7 +33,7 @@ const Index = () => {
           <div className="w-full md:w-[47.25%] h-[300px] sm:h-[400px] md:h-[500px]">
             <div className="relative w-full h-full">
               <Image
-                src="/Images/our-mission.webp"
+                src={assetPath('/Images/our-mission.webp')}
                 alt="Our Mission"
                 fill
                 className="object-cover rounded-[6px]"

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import Link from 'next/link'
 import { Mail, Phone, MapPin, ArrowRight } from 'lucide-react'
+import { assetPath } from '@/lib/assetPath'
 
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
@@ -35,7 +36,10 @@ const Footer: React.FC = () => {
               href="https://www.guidestar.org/profile/46-2471893"
               aria-label="View Free For Charity GuideStar Profile"
             >
-              <img src="/Svgs/footerImage.svg" alt="GuideStar Platinum Seal of Transparency" />
+              <img
+                src={assetPath('/Svgs/footerImage.svg')}
+                alt="GuideStar Platinum Seal of Transparency"
+              />
             </a>
             <Link
               href="https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742"

--- a/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -7,7 +8,7 @@ const index = () => {
         <div className="w-full md:w-[38.2%] mr-[32px]">
           <div className="rounded-[15px] overflow-hidden shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] w-full">
             <img
-              src="/Images/About-FFC-Hosting.webp"
+              src={assetPath('/Images/About-FFC-Hosting.webp')}
               alt="Example"
               className="w-full h-auto object-cover"
             />

--- a/src/components/free-charity-web-hosting/BecomePartOfOurMission/index.tsx
+++ b/src/components/free-charity-web-hosting/BecomePartOfOurMission/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import BecomePartOfOurMissionCard from '@/components/ui/BecomePartOfOurMissionCard'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -14,7 +15,7 @@ const index = () => {
       </div>
       <div className="w-[90%] lg:w-[80%] mx-auto pt-[27px] flex flex-col md:flex-row gap-[32px]">
         <BecomePartOfOurMissionCard
-          bgImage="/Images/help-us.webp"
+          bgImage={assetPath('/Images/help-us.webp')}
           heading="HELP US"
           description1="INDIVIDUALS OR BUSINESSES LOOKING"
           description2="FOR A DOMAIN NAME PACKAGE"
@@ -23,7 +24,7 @@ const index = () => {
         />
 
         <BecomePartOfOurMissionCard
-          bgImage="/Images/help-team.webp"
+          bgImage={assetPath('/Images/help-team.webp')}
           heading="HELP THEM"
           description1="FREE FOR CHARITY DOMAIN PACKAGE"
           description2="(NOT-FOR-PROFIT, PRE-501(C)3, FULL 501(C)3)"

--- a/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
+++ b/src/components/free-charity-web-hosting/ClientTestimonials/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { assetPath } from '@/lib/assetPath'
 
 const testimonials = [
   {
@@ -65,7 +66,7 @@ export default function TestimonialSlider() {
           <div
             className="absolute inset-0 bg-cover bg-bottom"
             style={{
-              backgroundImage: `url('/Images/client-section-bg-image.webp')`,
+              backgroundImage: `url('${assetPath('/Images/client-section-bg-image.webp')}')`,
             }}
           ></div>
 

--- a/src/components/free-charity-web-hosting/Hero/index.tsx
+++ b/src/components/free-charity-web-hosting/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -30,7 +31,7 @@ const Index = () => {
         {/* Right Section */}
         <div className="w-full md:w-[58%] relative h-[400px] md:h-[500px]">
           <Image
-            src="/Images/hero-charity.webp"
+            src={assetPath('/Images/hero-charity.webp')}
             alt="hero image"
             fill
             className="object-cover w-full h-full"

--- a/src/components/free-charity-web-hosting/ThreeCards/index.tsx
+++ b/src/components/free-charity-web-hosting/ThreeCards/index.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const DonateSection: React.FC = () => {
   return (
@@ -11,7 +12,7 @@ const DonateSection: React.FC = () => {
         <div className="w-full bg-[#0d7ff8] rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] flex flex-col items-center">
           <div className="mb-[30px] w-full relative h-[128px]">
             <Image
-              src="/Images/donate-now.webp"
+              src={assetPath('/Images/donate-now.webp')}
               alt="Donate Now"
               fill
               className="object-contain"
@@ -44,7 +45,7 @@ const DonateSection: React.FC = () => {
         <div className="w-full bg-[#0d7ff8] rounded-[10px] overflow-hidden pt-[30px] pr-[20px] pb-[30px] pl-[20px] shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)] flex flex-col items-center">
           <div className="mb-[30px] w-full relative h-[128px]">
             <Image
-              src="/Images/Be-a-volunteer.webp"
+              src={assetPath('/Images/Be-a-volunteer.webp')}
               alt="Be a Volunteer"
               fill
               className="object-contain"

--- a/src/components/free-charity-web-hosting/hosting/index.tsx
+++ b/src/components/free-charity-web-hosting/hosting/index.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const HeroSection = () => {
   return (
@@ -26,7 +27,7 @@ const HeroSection = () => {
         <div className="w-full md:w-[47%] mx-auto">
           <div className="w-full md:w-[80%] mx-auto relative h-[400px] md:h-[272px] rounded-[15px] overflow-hidden shadow-[0px_2px_18px_0px_rgba(0,0,0,0.3)]">
             <Image
-              src="/Images/heart-in-hands.webp"
+              src={assetPath('/Images/heart-in-hands.webp')}
               alt="hero image"
               fill
               className="object-cover"

--- a/src/components/guidestar-guide/Faqs/index.tsx
+++ b/src/components/guidestar-guide/Faqs/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import AccordionBold from '@/components/ui/AccordionBold'
 import Image from 'next/image'
 import Transparentbtn from '@/components/ui/Transparentbtn'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -230,7 +231,7 @@ const index = () => {
             as well as some option for posting this badge to your website that we will need later.
           </p>
           <Image
-            src="/Images/preparing-to-share.webp"
+            src={assetPath('/Images/preparing-to-share.webp')}
             alt="Free For Charity GuideStar onboarding requirements and highlighted fields"
             width={780}
             height={100}

--- a/src/components/guidestar-guide/Free-for-charity/index.tsx
+++ b/src/components/guidestar-guide/Free-for-charity/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   return (
@@ -29,7 +30,7 @@ const Index = () => {
         {/* Responsive Image with Proper Dimensions */}
         <div className="relative w-full h-auto">
           <Image
-            src="/Images/free-for-charity.webp"
+            src={assetPath('/Images/free-for-charity.webp')}
             alt="Free For Charity GuideStar onboarding requirements and highlighted fields"
             width={780}
             height={100}

--- a/src/components/home-page/Endowment-Features/index.tsx
+++ b/src/components/home-page/Endowment-Features/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { SustainableFundingCard } from '@/components/ui/SustainableFundingCard'
+import { assetPath } from '@/lib/assetPath'
 
 const Home: React.FC = () => {
   return (
@@ -14,22 +15,22 @@ const Home: React.FC = () => {
           </h1>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-[24px]">
             <SustainableFundingCard
-              imageUrl="/Svgs/sustainable-funding.svg"
+              imageUrl={assetPath('/Svgs/sustainable-funding.svg')}
               title="Sustainable Funding"
               text="The Endowment ensures that only the investment gains are used, providing a sustainable funding source for the Free For Charity Domain Program."
             />
             <SustainableFundingCard
-              imageUrl="/Svgs/Long-Term-Impact.svg"
+              imageUrl={assetPath('/Svgs/Long-Term-Impact.svg')}
               title="Long-Term Impact"
               text="By supporting the Endowment, you contribute to a lasting legacy that will continuously support charities in need of digital resources."
             />
             <SustainableFundingCard
-              imageUrl="/Svgs/Goal-of-$1,000,000.svg"
+              imageUrl={assetPath('/Svgs/Goal-of-$1,000,000.svg')}
               title="Goal of $1,000,000"
               text="Our target is to raise $1,000,000 to secure the future of the program, ensuring ongoing support for countless charities."
             />
             <SustainableFundingCard
-              imageUrl="/Svgs/Be-a-Champion.svg"
+              imageUrl={assetPath('/Svgs/Be-a-Champion.svg')}
               title="Be a Champion for Change"
               text="By taking donations on our behalf, you become an essential part of our mission, creating a ripple effect of generosity and support."
             />

--- a/src/components/home-page/Hero/index.tsx
+++ b/src/components/home-page/Hero/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const CharityHeroBackground = () => {
   return (
@@ -65,7 +66,7 @@ const CharityHeroBackground = () => {
         <div className="relative w-full max-w-[445px] aspect-square bg-white rounded-full p-12 flex items-center justify-center">
           <div className="relative w-full h-full">
             <Image
-              src="/Images/figma-hero-img.webp"
+              src={assetPath('/Images/figma-hero-img.webp')}
               alt="Hero image"
               fill
               className="object-contain"

--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -31,11 +32,11 @@ const index = () => {
             controls
             playsInline
             preload="metadata"
-            poster="/videos/mission-video-poster.webp"
+            poster={assetPath('/videos/mission-video-poster.webp')}
             aria-label="Free For Charity mission video"
             title="Learn about Free For Charity's mission to help nonprofits reduce costs"
           >
-            {/* <source src="/videos/mission-video.mp4" type="video/mp4" /> */}
+            {/* <source src={assetPath('/videos/mission-video.mp4')} type="video/mp4" /> */}
             <source src="https://ffcsites.org/videos/mission-video.mp4" type="video/mp4" />
             Your browser does not support the video tag.
           </video>

--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Image from 'next/image'
 import OrangeFaqItem from '@/components/ui/OrangeFaqItem'
 import ApplicationFormButton from '@/components/ui/ApplicationFormButton'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -18,7 +19,7 @@ const index = () => {
           <div className="mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src="/Svgs/FFC-Domains.svg" alt="FFC-Domains" fill></Image>
+                <Image src={assetPath('/Svgs/FFC-Domains.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400] " id="lato-font">
@@ -74,7 +75,7 @@ const index = () => {
           <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src="/Svgs/FFC-Hosting.svg" alt="FFC-Domains" fill></Image>
+                <Image src={assetPath('/Svgs/FFC-Hosting.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400]  " id="lato-font">
@@ -140,7 +141,7 @@ const index = () => {
           <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src="/Svgs/FFC-Consulting.svg" alt="FFC-Domains" fill></Image>
+                <Image src={assetPath('/Svgs/FFC-Consulting.svg')} alt="FFC-Domains" fill></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400]  " id="lato-font">

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, IframeHTMLAttributes } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface ExtendedIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
   allowpaymentrequest?: string
@@ -50,7 +51,7 @@ const Index = () => {
             <div className="w-full flex justify-center lg:justify-end">
               <div className="relative w-full max-w-[400px] aspect-[578/386]">
                 <Image
-                  src="/Images/support-free-for-charity.webp"
+                  src={assetPath('/Images/support-free-for-charity.webp')}
                   alt="support free for charity image"
                   fill
                   className="object-contain scale-x-[-1]"

--- a/src/components/home-page/TheFreeForCharityTeam/index.tsx
+++ b/src/components/home-page/TheFreeForCharityTeam/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import TeamMemberCard from '@/components/ui/TeamMemberCard'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -14,19 +15,19 @@ const index = () => {
       <div className="w-[90%] mx-auto py-[40px]">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3  items-stretch justify-center mb-[50px] gap-[30px]">
           <TeamMemberCard
-            imageUrl="/Images/member1.webp"
+            imageUrl={assetPath('/Images/member1.webp')}
             name="Clarke Moyer"
             title="Free For Charity Founder/ President of the Board"
             linkedinUrl="https://www.linkedin.com/in/clarkemoyer/"
           />
           <TeamMemberCard
-            imageUrl="/Images/member2.webp"
+            imageUrl={assetPath('/Images/member2.webp')}
             name="Chris Rae"
             title="Free For Charity Vice President"
             linkedinUrl="https://www.linkedin.com/in/christopher-rae-540493a5/"
           />
           <TeamMemberCard
-            imageUrl="/Images/member3.webp"
+            imageUrl={assetPath('/Images/member3.webp')}
             name="Tyler Carlotto"
             title="Free For Charity Secretary"
             linkedinUrl="https://www.linkedin.com/in/tylercarlotto/"
@@ -34,13 +35,13 @@ const index = () => {
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 items-center justify-center mt-[40px] gap-[30px]">
           <TeamMemberCard
-            imageUrl="/Images/member4.webp"
+            imageUrl={assetPath('/Images/member4.webp')}
             name="Brennan Darling"
             title="Free For Charity Treasurer"
             linkedinUrl="https://www.linkedin.com/in/brennon-darling-80953038/"
           />
           <TeamMemberCard
-            imageUrl="/Images/member5.webp"
+            imageUrl={assetPath('/Images/member5.webp')}
             name="Rebecca Cook"
             title="Free For Charity Member at Large"
             linkedinUrl="https://www.linkedin.com/in/rebecca-cook-a91599265/"

--- a/src/components/home-page/VoicesofGratitude/index.tsx
+++ b/src/components/home-page/VoicesofGratitude/index.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 export default function TestimonialSlider() {
   const testimonials = [
@@ -77,7 +78,7 @@ export default function TestimonialSlider() {
                           {[...Array(testimonial.rating)].map((_, i) => (
                             <Image
                               key={i}
-                              src="/Svgs/start-icon.svg"
+                              src={assetPath('/Svgs/start-icon.svg')}
                               width={29}
                               height={29}
                               alt="start icon"

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -32,7 +33,7 @@ const index = () => {
         </a>
 
         <Image
-          src="/Images/Volunteer-with-Us.webp"
+          src={assetPath('/Images/Volunteer-with-Us.webp')}
           alt="Volunteer-with-Us"
           width={1083}
           height={607}

--- a/src/components/home/HeroSection/index.tsx
+++ b/src/components/home/HeroSection/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 const Hero: React.FC = () => {
   return (
@@ -21,7 +22,7 @@ const Hero: React.FC = () => {
         {/* Right Image Section */}
         <div className="w-full md:w-[60%] flex items-center justify-center md:justify-end pt-[50px] md:pt-[50px]">
           <Image
-            src="/Images/hero-image.webp"
+            src={assetPath('/Images/hero-image.webp')}
             alt="Hero"
             width={800}
             height={540}

--- a/src/components/home/Ourblogs/index.tsx
+++ b/src/components/home/Ourblogs/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import InfoCard from '../../ui/BlogCard'
+import { assetPath } from '@/lib/assetPath'
 
 interface Blog {
   heading: string
@@ -16,7 +17,7 @@ const OutBlogs: React.FC = () => {
       date: 'Jan 9, 2023',
       description:
         "We're excited to share that our organization has earned a 2022 Platinum Seal of Transparency with Candid! Now, you can support our work with trust and confidence by viewing our nonprofit profile Free For Charity - GuideStar Profile",
-      imageUrl: '/Images/card-image.webp',
+      imageUrl: assetPath('/Images/card-image.webp'),
       href: 'https://freeforcharity.org/we-just-updated-for-the-2022-guidestar-platinum-seal/', // example link
     },
     {

--- a/src/components/home/SupportFreeforCharity/index.tsx
+++ b/src/components/home/SupportFreeforCharity/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import TrainingCard from '../../ui/trainingcard'
 import BlueBtn from '../../ui/Bluebtn'
 import Transparentbtn from '@/components/ui/Transparentbtn'
+import { assetPath } from '@/lib/assetPath'
 
 const SupportFreeForCharity: React.FC = () => {
   return (
@@ -40,7 +41,7 @@ const SupportFreeForCharity: React.FC = () => {
               TRAINING PROGRAM.
             </h1>
             <TrainingCard
-              src="/Svgs/tickmark.svg"
+              src={assetPath('/Svgs/tickmark.svg')}
               heading="FREE TRAINING PROGRAMS"
               text="Are you looking to gain marketable skills in technology and business services? Are you looking to start building a portfolio showing real world support to small, medium, and large organizations? If so, this is the place for you."
             />
@@ -57,7 +58,7 @@ const SupportFreeForCharity: React.FC = () => {
               PROJECTS.
             </h1>
             <TrainingCard
-              src="/Svgs/home.svg"
+              src={assetPath('/Svgs/home.svg')}
               heading="CHARITY ONBOARDING"
               text="If you are representing a charity or you currently work for a charity and want to improve your own skills start here to get help for your organization. You get instant access to many of our free tools and products right away!"
             />
@@ -73,7 +74,7 @@ const SupportFreeForCharity: React.FC = () => {
               ARE YOU A BUSINESS OR INDIVIDUAL LOOKING TO DONATE OR PARTNER WITH FREE FOR CHARITY?
             </h1>
             <TrainingCard
-              src="/Svgs/heart.svg"
+              src={assetPath('/Svgs/heart.svg')}
               heading="VOLUNTEER AND/OR DONATE"
               text="We are always looking for individuals and business to support our training programs. Both donations as well as performing volunteer work for our training programs are critical to the success of Free For Charity and it’s mission."
             />

--- a/src/components/tools-for-success/Card-section/index.tsx
+++ b/src/components/tools-for-success/Card-section/index.tsx
@@ -1,4 +1,5 @@
 import SlidingCard from '@/components/ui/SlidingCard'
+import { assetPath } from '@/lib/assetPath'
 
 export default function Page() {
   return (
@@ -18,7 +19,7 @@ export default function Page() {
           }
           buttonText="Available Here"
           buttonLink="https://lastpass.com/friendwelcome.php?og=1&ref=47075402"
-          imageSrc="/Images/LastPass-Logo-Color.webp"
+          imageSrc={assetPath('/Images/LastPass-Logo-Color.webp')}
         />
         <SlidingCard
           direction="left"
@@ -33,7 +34,7 @@ export default function Page() {
           }
           buttonText="Available Here"
           buttonLink="mint.com"
-          imageSrc="/Images/mint-logo.webp" // 👈 image passed as prop
+          imageSrc={assetPath('/Images/mint-logo.webp')} // 👈 image passed as prop
         />
       </div>
     </div>

--- a/src/components/tools-for-success/Educational-Sites/index.tsx
+++ b/src/components/tools-for-success/Educational-Sites/index.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import Image from 'next/image'
 import { IoIosArrowForward } from 'react-icons/io'
 import { motion, Variants } from 'framer-motion'
+import { assetPath } from '@/lib/assetPath'
 
 const cardVariants: Variants = {
   offscreen: { opacity: 0, scale: 0.8 },
@@ -19,12 +20,12 @@ const EducationalSitesSection = () => {
     {
       title: 'iwillteachyoutoberich.com Best for automation and earning more',
       link: 'https://www.iwillteachyoutoberich.com/blog/',
-      image: '/Images/googleLogo.webp',
+      image: assetPath('/Images/googleLogo.webp'),
     },
     {
       title: 'fourhourworkweek.com Another prime automation book and website',
       link: 'https://tim.blog/overview/',
-      image: '/Images/googleLogo.webp',
+      image: assetPath('/Images/googleLogo.webp'),
     },
   ]
 

--- a/src/components/tools-for-success/Five-Cards-Grid-Section/index.tsx
+++ b/src/components/tools-for-success/Five-Cards-Grid-Section/index.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import EducationalSitesCard from '@/components/ui/EducationalSitesCard'
 import { motion, Variants } from 'framer-motion'
+import { assetPath } from '@/lib/assetPath'
 
 const cardVariants: Variants = {
   offscreen: { opacity: 0, scale: 0.8 },
@@ -16,17 +17,17 @@ const cardVariants: Variants = {
 const index = () => {
   const firstGrid = [
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'ittybiz.com Great site for ultra small business info',
       link: 'http://ittybiz.com/about/',
     },
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'earn1k.com Program for earning your for $1000 on the side by Ramit',
       link: 'http://earn1k.com/',
     },
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'appsumo.com Another program for earning your first money online',
       link: 'https://appsumo.com/courses-learning/',
     },
@@ -34,12 +35,12 @@ const index = () => {
 
   const secondGrid = [
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: '100startup.com First book on starting a business',
       link: 'https://100startup.com/',
     },
     {
-      imageSrc: '/Images/upwork.webp',
+      imageSrc: assetPath('/Images/upwork.webp'),
       title: 'theleanstartup.com The next step up book on starting a business',
       link: 'http://theleanstartup.com/',
     },

--- a/src/components/tools-for-success/Six-Grid-Cards/index.tsx
+++ b/src/components/tools-for-success/Six-Grid-Cards/index.tsx
@@ -1,25 +1,26 @@
 'use client'
 
 import ToolCard from '@/components/ui/ToolCard'
+import { assetPath } from '@/lib/assetPath'
 
 export default function ToolsPage() {
   const topRow = [
     {
-      logo: '/Images/quickbooksLogo.webp',
+      logo: assetPath('/Images/quickbooksLogo.webp'),
       title: 'QuickBooks Online ($75 per year with 5 users)',
       description:
         'If your accounting is not right a lot will suffer. Techsoup offers the discounts for QuickBooks the industry leader in accounting. Both online and offline versions are offered at the same price.',
       link: 'https://www.techsoup.org/products/quickbooks-online-plus--1-year-initial-subscription--5-users--G-49616--',
     },
     {
-      logo: '/Images/googleLogo.webp',
+      logo: assetPath('/Images/googleLogo.webp'),
       title: 'Google Workspace for non-profits (free with paid plans)',
       description:
         'apps including Gmail and grant options for free AdWords advertisements. If you do not like or have not used outlook choose this for Gmail and free storage space with google drive.',
       link: 'https://www.google.com/nonprofits/',
     },
     {
-      logo: '/Images/officeLogo.webp',
+      logo: assetPath('/Images/officeLogo.webp'),
       title: 'Microsoft Office 365 enterprise for non-profits (free with paid packages)',
       description:
         'NOTE: FFC Recomended — Incredible discounts for non profits at rates better than even students get for advanced enterprise features. This should be the first product you seek to get.',
@@ -29,21 +30,21 @@ export default function ToolsPage() {
 
   const bottomRow = [
     {
-      logo: '/Images/upwork.webp',
+      logo: assetPath('/Images/upwork.webp'),
       title: 'Salesforce (free to nonprofits up to 10 seats per year)',
       description:
         'Worlds best CRM available. NOTE: Microsoft offer now includes CRM for an all in one solution.',
       link: 'http://www.salesforcefoundation.org/nonprofit/',
     },
     {
-      logo: '/Images/grantstationLogo.webp',
+      logo: assetPath('/Images/grantstationLogo.webp'),
       title: 'GrantStation (199$ per year)',
       description:
         'Best tool if you have a dedicated grant writer or a grant worthy type of charity.',
       link: 'http://www.techsoup.org/products/grantstation-%28discounted%29--G-2575-',
     },
     {
-      logo: '/Images/mailchimpLogo.webp',
+      logo: assetPath('/Images/mailchimpLogo.webp'),
       title: 'MailChimp(offers multiple packages paid ones are 15% off for non-profits)',
       description: 'mailchimp is an always-on marketing platform for small businesses.',
       link: 'https://mailchimp.com/pricing/marketing/',

--- a/src/components/tools-for-success/Tools-For-Businesses/index.tsx
+++ b/src/components/tools-for-success/Tools-For-Businesses/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import SlidingCard from '@/components/ui/SlidingCard'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -29,7 +30,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://www.waveapps.com/"
-            imageSrc="/Images/Wave-logo.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/Wave-logo.webp')} // 👈 image passed as prop
           />
           <SlidingCard
             direction="right"
@@ -48,7 +49,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://www.shoeboxed.com/"
-            imageSrc="/Images/shoeboxed.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/shoeboxed.webp')} // 👈 image passed as prop
           />
 
           <SlidingCard
@@ -65,7 +66,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://www.google.com/enterprise/apps/business/"
-            imageSrc="/Images/google.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/google.webp')} // 👈 image passed as prop
           />
 
           <SlidingCard
@@ -80,7 +81,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="http://fiverr.com/"
-            imageSrc="/Images/fiverr.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/fiverr.webp')} // 👈 image passed as prop
           />
 
           <SlidingCard
@@ -95,7 +96,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://www.odesk.com/"
-            imageSrc="/Images/upwork.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/upwork.webp')} // 👈 image passed as prop
           />
         </div>
       </div>

--- a/src/components/tools-for-success/Two-Cards-With-Heading/index.tsx
+++ b/src/components/tools-for-success/Two-Cards-With-Heading/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import SlidingCard from '@/components/ui/SlidingCard'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -32,7 +33,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://www.guidestar.org/"
-            imageSrc="/Images/guidestar.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/guidestar.webp')} // 👈 image passed as prop
           />
           <SlidingCard
             direction="left"
@@ -48,7 +49,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://www.techsoup.org/"
-            imageSrc="/Images/TechSouplogo.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/TechSouplogo.webp')} // 👈 image passed as prop
           />
 
           <div className="py-[6px] w-[80%] mx-auto">

--- a/src/components/tools-for-success/Two-Cards/index.tsx
+++ b/src/components/tools-for-success/Two-Cards/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import SlidingCard from '@/components/ui/SlidingCard'
+import { assetPath } from '@/lib/assetPath'
 
 const index = () => {
   return (
@@ -22,7 +23,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://nonprofit.linkedin.com/"
-            imageSrc="/Images/Linkedin-logo.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/Linkedin-logo.webp')} // 👈 image passed as prop
           />
           <SlidingCard
             direction="right"
@@ -42,7 +43,7 @@ const index = () => {
             }
             buttonText="Available Here"
             buttonLink="https://www.nuance.com/dragon.html"
-            imageSrc="/Images/dragon-logo.webp" // 👈 image passed as prop
+            imageSrc={assetPath('/Images/dragon-logo.webp')} // 👈 image passed as prop
           />
         </div>
       </div>

--- a/src/components/tools-for-success/Two-Flex-Cards/index.tsx
+++ b/src/components/tools-for-success/Two-Flex-Cards/index.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef } from 'react'
 import Image from 'next/image'
 import { IoIosArrowForward } from 'react-icons/io'
+import { assetPath } from '@/lib/assetPath'
 
 const Index = () => {
   const sectionRef = useRef<HTMLDivElement | null>(null)
@@ -34,7 +35,7 @@ const Index = () => {
           {/* Image */}
           <div className="relative w-full h-[260px] mb-[30px]">
             <Image
-              src="/Images/Volunteer-Card.webp"
+              src={assetPath('/Images/Volunteer-Card.webp')}
               alt="Placeholder Image"
               fill
               className="object-cover"
@@ -77,7 +78,7 @@ const Index = () => {
         <div className="w-[100%] lg:w-[47.25%] rounded-[15px] shadow-[0px_2px_70px_-15px_rgba(0,0,0,0.3)] py-[40px] px-[20px] flex flex-col items-start">
           <div className="relative w-full h-[260px] mb-[30px]">
             <Image
-              src="/Images/Free-For-Charity-card.webp"
+              src={assetPath('/Images/Free-For-Charity-card.webp')}
               alt="Placeholder Image"
               fill
               className="object-cover"

--- a/src/components/ui/Frequently-Asked-Questions.tsx
+++ b/src/components/ui/Frequently-Asked-Questions.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useLayoutEffect } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface AccordionItemProps {
   title: string
@@ -40,9 +41,19 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
         {/* Icon container with fixed width */}
         <span className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
           {isOpen ? (
-            <Image src="/Svgs/up-arrow.svg" alt="up arrow" width={40} height={13}></Image>
+            <Image
+              src={assetPath('/Svgs/up-arrow.svg')}
+              alt="up arrow"
+              width={40}
+              height={13}
+            ></Image>
           ) : (
-            <Image src="/Svgs/down-arrow.svg" alt="up arrow" width={40} height={16}></Image>
+            <Image
+              src={assetPath('/Svgs/down-arrow.svg')}
+              alt="up arrow"
+              width={40}
+              height={16}
+            ></Image>
           )}
         </span>
       </button>

--- a/src/components/ui/OrangeFaqItem.tsx
+++ b/src/components/ui/OrangeFaqItem.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useLayoutEffect } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface AccordionItemProps {
   title: string
@@ -45,9 +46,9 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
 
         <span className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
           {isOpen ? (
-            <Image width={51} height={51} src="/Svgs/minus.svg" alt="Minus" />
+            <Image width={51} height={51} src={assetPath('/Svgs/minus.svg')} alt="Minus" />
           ) : (
-            <Image width={51} height={51} src="/Svgs/plus.svg" alt="Plus" />
+            <Image width={51} height={51} src={assetPath('/Svgs/plus.svg')} alt="Plus" />
           )}
         </span>
       </button>

--- a/src/components/ui/StepCard.tsx
+++ b/src/components/ui/StepCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface Step {
   number: number
@@ -45,7 +46,7 @@ const StepCard: React.FC<{ step: Step }> = ({ step }) => {
         <div className="flex justify-center mb-[30px]">
           <div className="relative w-[100px] h-[100px]">
             <Image
-              src={`/Images/${step.number}.webp`}
+              src={assetPath(`/Images/${step.number}.webp`)}
               alt={`Step ${step.number}`}
               fill
               className={`object-contain drop-shadow-lg transition-all duration-700 ${

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Image from 'next/image'
+import { assetPath } from '@/lib/assetPath'
 
 interface TeamMemberCardProps {
   imageUrl: string
@@ -43,7 +44,12 @@ export default function TeamMemberCard({
 
         {/* LinkedIn Button */}
         <a href={linkedinUrl} target="_blank" rel="noopener noreferrer" className="mt-6">
-          <Image src="/Svgs/linkedin-icon.svg" width={63} height={63} alt="linkedin icon"></Image>
+          <Image
+            src={assetPath('/Svgs/linkedin-icon.svg')}
+            width={63}
+            height={63}
+            alt="linkedin icon"
+          ></Image>
         </a>
       </div>
 


### PR DESCRIPTION
## Summary

The drift checker has been warning on **88 raw `/Images/...` / `/Svgs/...` / `/videos/...` literals** across 44 component files since #257 landed. Every one of those would 404 on a GitHub Pages subpath deploy because they bypassed the `assetPath()` helper that prepends `NEXT_PUBLIC_BASE_PATH`.

This PR closes the loop:

1. **Wraps all 88 literals in `assetPath()`** — covers JSX attribute strings (`src="/Images/foo.webp"`), template literals (`src={\`/Images/${x}.webp\`}`), prop-object values (`img: "/Images/foo.gif"`), and inline-style URLs (`backgroundImage: \`url('...')\``).
2. **Adds the `import { assetPath } from '@/lib/assetPath'` line** to every file that needed it (didn't have one already).
3. **Upgrades the drift checker's `assetPath` rule from WARNING to ERROR** now that the codebase is clean. Any new occurrence will fail CI instead of silently piling up under the existing baseline.

## Why this matters

- **Production bug fix**: Every charity that forks the template and deploys to `<org>.github.io/<repo>/` was getting broken images for these 88 assets (custom-domain deploys masked the problem because `NEXT_PUBLIC_BASE_PATH` is empty there).
- **Drift floor moves down**: Repo now shows `✅ No drift detected` — clean baseline means future warnings actually signal regressions instead of being lost in noise.
- **No new APIs**: Just consistent use of the existing helper from #257.

## Verification

- `npm run format` — clean (Prettier reformatted nothing)
- `npm run lint` — 0 errors (7 pre-existing warnings unchanged)
- `npm run check:drift` — **0 errors, 0 warnings** (was 0 errors, 88 warnings)
- `npm test` — 41/41
- `npm run build` — 12 routes generated cleanly, including `/manifest.webmanifest`
- Spot-checked diffs across `home-page/TheFreeForCharityTeam`, `tools-for-success/Six-Grid-Cards`, `domains/Verify-Your-Domain`, `ui/StepCard`, and the `ClientTestimonials` inline-style `url(...)` case — all transformations produced the expected `assetPath('/...')` wrappers and added the import.

## Methodology

Wrote a one-shot Node codemod (`scripts/fix-assetpath.mjs`), ran it, then deleted it — the drift checker is the durable enforcement going forward. The codemod handled three patterns automatically, and I fixed the one inline-style `backgroundImage: url('...')` case by hand (template literal interpolation, didn't match any of the three regexes).

## Notes

This PR depends on #257 (assetPath helper exists in main already). It does not depend on #258 (README prompt) or #259 (Footer/manifest/drift hardening) and can land in any order.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G73s7idxoHDUsTPyE8tF8h)_