### PR TITLE
docs(onboarding): fix gh-pages misinformation and expand onboarding agent

### DIFF
--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -1,6 +1,6 @@
 ---
 name: onboarding
-description: Walk a new FFC charity through customizing this template — site config, content swap-out, CNAME, GitHub Pages settings, secrets, and a final verification run.
+description: Walk a new FFC charity through customizing this template — site config, content swap-out, CNAME, deploy workflow, GitHub Pages settings, secrets, and a final verification run.
 tools: Bash, Read, Edit, Write, Glob, Grep
 ---
 
@@ -10,33 +10,76 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
 
 1. **Confirm scope.** Ask the charity for:
    - Display name and short tagline (one sentence each).
-   - Description paragraph for SEO / OG cards (1-2 sentences).
+   - SEO description (1–2 sentences) and a shorter card description for OG / Twitter previews.
    - Production URL (custom domain) — if none yet, default to the GitHub Pages URL.
-   - Twitter/X handle (optional), security/contact email, primary social links.
-2. **Update `src/lib/site.config.ts`** with the values above. This is the canonical source — never duplicate.
+   - Twitter/X handle (optional), primary contact email, security disclosure email, primary social links (Facebook, X, LinkedIn, GitHub, others).
+   - EIN, mailing address(es), phone number(s) — the footer still hardcodes these.
+
+2. **Update `src/lib/site.config.ts`** with the values above. This is the canonical source — never duplicate. Helpers (`siteUrl`, `twitterSite`, `cardDescription`) drive layout/robots/sitemap/manifest/footer; do NOT change their signatures.
+
 3. **Update `public/CNAME`** if a custom domain is being used; otherwise delete it.
+
 4. **Update `public/.well-known/security.txt`**:
-   - `Contact:` matches `siteConfig.contactEmail`
+   - `Contact:` matches the security disclosure email
    - `Canonical:` / `Policy:` / `Acknowledgments:` use the new URL
-   - `Expires:` is at least 12 months out
-5. **Swap branded assets** in `public/Images/` and `public/Svgs/`. Keep filenames so layout preloads still hit.
-6. **Replace content** in `src/data/` (testimonials, FAQs, team) and the home-page sections.
-7. **Run the pre-commit gauntlet**:
-   ```
-   npm run format
-   npm run lint
-   npm run check:drift
-   npm test
-   npm run build
-   npm run test:e2e
-   ```
-   Fix anything red before opening a PR.
-8. **Open a PR titled** `chore: initial customization for <Charity Name>` linking the onboarding issue.
-9. **After merge**: confirm GitHub Pages is enabled (`Settings → Pages → GitHub Actions`) and the deploy workflow has run green.
+   - `Expires:` is at least 12 months out, formatted `YYYY-MM-DDTHH:MM:SSZ`
+
+5. **Update `.github/workflows/deploy.yml` and `.github/workflows/lighthouse.yml`**:
+   - Change `NEXT_PUBLIC_BASE_PATH` from `/FFC_Single_Page_Template` to `/your-repo-name` if you renamed the repo for a github.io subpath fallback. If using a custom domain only, you can leave the value as-is (the CNAME takes precedence at the host level).
+
+6. **Swap branded assets** in `public/Images/` and `public/Svgs/`. Keep filenames where possible so the LCP preload in `layout.tsx` and the manifest icons still hit real files.
+
+7. **Edit the footer** in `src/components/footer/index.tsx`:
+   - EIN, mailing addresses (Raleigh + State College), phone number, GuideStar profile URL, and the parent-organization link at the bottom are all hardcoded — replace with the charity's real info.
+   - The social-link rail and email already come from `siteConfig`; don't duplicate them.
+
+8. **Replace content** in `src/data/` (testimonials, FAQs, team) and the home-page sections under `src/components/home-page/`.
+
+9. **Legal pages** under `src/app/{privacy-policy,terms-of-service,cookie-policy,donation-policy}` — REVIEW with the charity's counsel before committing. Update org name and contact references.
+
+10. **GitHub repo settings** (web UI, not in code):
+    - Settings → Pages → Source = **"GitHub Actions"** (NOT "Deploy from a branch" — there is no `gh-pages` branch).
+    - Settings → Actions → General → workflow permissions = "Read and write".
+    - Add custom domain in Settings → Pages and enable "Enforce HTTPS" once DNS resolves.
+    - Add `clarkemoyer` or the charity's maintainer as Admin.
+
+11. **Update repo-level metadata**: `README.md` (top section, deployment URL, Quick Links), `CITATION.cff` (org name, author), GitHub repo description and topics.
+
+12. **Run the pre-commit gauntlet**:
+
+    ```
+    npm install
+    npm run format
+    npm run lint
+    npm run check:drift   # MUST be 0 errors; warnings should not increase
+    npm test
+    npm run build
+    npm run test:e2e
+    ```
+
+    Fix anything red before opening a PR.
+
+13. **Open a PR titled** `chore: initial customization for <Charity Name>` linking the onboarding issue. In the body include:
+    - A checklist of every file edited
+    - Output of `npm run check:drift`
+    - Confirmation that legal pages were reviewed by counsel
+    - The production URL (or "github.io fallback only" if no domain yet)
+
+14. **After merge**: confirm the deploy workflow runs green, then visit the site and verify:
+    - Custom domain serves over HTTPS
+    - `/.well-known/security.txt` returns 200 with the new contact / canonical / expires
+    - `/manifest.webmanifest` returns 200 with the charity's name / colors
+    - `/sitemap.xml` and `/robots.txt` reference the new URL
+    - OG/Twitter card preview (use Facebook Sharing Debugger / Twitter Card Validator) shows the new branding
 
 ## Guardrails
 
 - Never paste API keys, GTM IDs, or secrets into committed files. Use GitHub Secrets / `.env` (gitignored).
-- Never rename route folders to non-kebab-case.
-- Never replace `assetPath('/Images/...')` with a bare string.
-- If the charity wants a feature not in the template (e.g., a contact form backend), open an issue first — static export limits some options.
+- Never rename route folders to non-kebab-case (CI will fail).
+- Never bypass `assetPath()` for `/Images/`, `/Svgs/`, or `/videos/` references (CI will fail).
+- Never add a third-party origin (analytics, embed, payment) to only one of `public/_headers` or the CSP `<meta>` in `src/app/layout.tsx`. The drift checker enforces sync; one-sided changes will fail CI.
+- If the charity wants a feature not in the template (contact form backend, members area, dynamic content), open an issue first — static export limits some options.
+
+## Reference
+
+The full field-to-surface map lives in `TEMPLATE_CUSTOMIZATION.md`. The setup checklist in `TEMPLATE_SETUP_CHECKLIST.md` covers GitHub repo settings. The drift checker (`scripts/check-drift.mjs`) describes the platform contract you're working within.

--- a/TEMPLATE_SETUP_CHECKLIST.md
+++ b/TEMPLATE_SETUP_CHECKLIST.md
@@ -29,11 +29,15 @@ Quick reference checklist for setting up a new repository from the FFC Single Pa
 
 ### GitHub Pages (Settings → Pages)
 
-- [ ] Source: Deploy from a branch
-- [ ] Branch: Select `gh-pages` and `/ (root)`
-- [ ] Custom domain (if applicable): Enter domain name
+- [ ] **Source: GitHub Actions** (NOT "Deploy from a branch" — this repo's
+      `.github/workflows/deploy.yml` uploads a Pages artifact via
+      `actions/deploy-pages`; there is no `gh-pages` branch)
+- [ ] Custom domain (if applicable): Enter domain name and click "Save"
 - [ ] Wait for DNS check to complete
 - [ ] Enable "Enforce HTTPS" (after DNS configured)
+- [ ] If using a github.io subpath fallback, also update
+      `NEXT_PUBLIC_BASE_PATH` in `.github/workflows/deploy.yml` and
+      `.github/workflows/lighthouse.yml` to `/your-repo-name`
 
 ### Actions Permissions (Settings → Actions → General)
 
@@ -241,10 +245,11 @@ Create ruleset named "Protect Main":
 
 ✅ **Solution**:
 
-1. Verify Pages source is `gh-pages` branch
+1. Verify Pages source is set to **"GitHub Actions"** (Settings → Pages → Source)
 2. Wait 2-5 minutes for propagation
-3. Check Actions tab for deployment status
-4. Verify `NEXT_PUBLIC_BASE_PATH` matches repo name
+3. Check Actions tab for the "Deploy to GitHub Pages" workflow status
+4. Verify `NEXT_PUBLIC_BASE_PATH` in `.github/workflows/deploy.yml` matches the repo name (e.g. `/my-charity-site`)
+5. If you have a custom domain, confirm `public/CNAME` contains it (no scheme, no trailing slash)
 
 ### Images don't load on GitHub Pages
 


### PR DESCRIPTION
## Summary

Two volunteer-facing docs that the post-merge round-C review caught as actively misleading — both would cause a brand-new charity site to ship broken.

### `TEMPLATE_SETUP_CHECKLIST.md`

The setup section said:
> Source: Deploy from a branch
> Branch: Select `gh-pages` and `/ (root)`

That's wrong — `deploy.yml` uploads a Pages artifact via `actions/deploy-pages`, and there is no `gh-pages` branch in this template. A volunteer following the checklist literally would set Pages source to the wrong value and get a permanent 404. The 404 troubleshooting section reinforced it: "Verify Pages source is `gh-pages` branch". Now corrected to **"Source: GitHub Actions"** with an explicit "NOT 'Deploy from a branch'" callout. Also added an explicit "update `NEXT_PUBLIC_BASE_PATH` in `deploy.yml` and `lighthouse.yml` for subpath deploys" step (previously omitted entirely).

### `.claude/agents/onboarding.md`

The previous flow had 9 steps and stopped after `siteConfig` + assets + the pre-commit gauntlet. The volunteer-perspective review showed the agent was shipping volunteers to a half-customized site:

- ❌ Never told them to edit `NEXT_PUBLIC_BASE_PATH` for github.io subpath deploys
- ❌ Never told them to edit the footer's still-hardcoded EIN / addresses / phone / GuideStar URL
- ❌ Never told them to set Pages source = "GitHub Actions" in repo settings
- ❌ Never told them to update README / CITATION.cff / repo description

The expanded onboarding now has 14 steps covering all of the above, plus a post-deploy verification step (security.txt, manifest, sitemap, OG cards) and explicit guardrails about the new CSP-sync enforcement and the now-error-level `assetPath` rule.

## Verification

- `npm run format` — clean
- `npm run check:drift` — 0 errors (88 pre-existing warnings, all in component files unrelated to this PR)
- `npm test` — 41/41

This PR is docs-only. Depends on `main` (post-#258 README merge); does not depend on #259 (footer/manifest/drift) or #260 (assetPath cleanup).


---
_Generated by [Claude Code](https://claude.ai/code/session_01G73s7idxoHDUsTPyE8tF8h)_