### PR TITLE
chore(template): cumulative-review follow-ups (CSP-sync, url validation, docs)

### DIFF
--- a/.claude/agents/site-health.md
+++ b/.claude/agents/site-health.md
@@ -22,7 +22,7 @@ You are checking the live health of an FFC-supported site. Default to the URL in
    - `/robots.txt` is 200 and lists `Sitemap:` pointing to `/sitemap.xml`.
    - `/sitemap.xml` is 200 and contains the home URL.
 6. **security.txt** — `/.well-known/security.txt` is 200, `Expires:` is in the future.
-7. **Favicons & manifest** — `/favicon.ico`, `/icon.png`, `/site.webmanifest` all 200.
+7. **Favicons & manifest** — `/favicon.ico`, `/icon.png` are 200. The manifest is served at `/manifest.webmanifest` (current — generated from siteConfig by `src/app/manifest.ts`) or `/site.webmanifest` (legacy, pre-#259). Try `/manifest.webmanifest` first; fall back to `/site.webmanifest`. Verify the response content-type is `application/manifest+json` or `application/json` (not HTML — `serve -s` SPA-falls-back to index.html on miss).
 8. **Broken links (optional)** — Suggest running `npm run check-links` locally if anything looks off.
 
 ## How to report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,10 @@ All changes follow this process:
 4. **Pre-commit checklist** (run in this order):
    1. `npm run format` -- Auto-fix formatting
    2. `npm run lint` -- Catch code quality issues
-   3. `npm test` -- Run unit tests
-   4. `npm run build` -- Verify the static export succeeds
-   5. `npm run test:e2e` -- Run end-to-end tests
+   3. `npm run check:drift` -- FFC best-practice enforcement (kebab-case routes, assetPath usage, CSP sync, committed-secret patterns, placeholder URLs)
+   4. `npm test` -- Run unit tests
+   5. `npm run build` -- Verify the static export succeeds
+   6. `npm run test:e2e` -- Run end-to-end tests
 5. **PR** -- Open a Pull Request, link to the issue with `Fixes #NNN` or `Refs #NNN`
 6. **Merge** -- Merge via merge queue (no direct commits to `main`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,12 @@ You have full terminal access via the Bash tool. Use it for all CLI operations.
 Run these in order before committing:
 
 ```bash
-npm run format    # Fix formatting
-npm run lint      # Check for lint errors
-npm test          # Run unit tests
-npm run build     # Verify static export
-npm run test:e2e  # Run E2E tests
+npm run format       # Fix formatting
+npm run lint         # Check for lint errors
+npm run check:drift  # FFC best-practice enforcement (kebab-case routes, assetPath usage, CSP sync, secret patterns, placeholder URLs)
+npm test             # Run unit tests
+npm run build        # Verify static export
+npm run test:e2e     # Run E2E tests
 ```
 
 If any step fails, fix the issue and re-run from that step forward.

--- a/README.md
+++ b/README.md
@@ -113,12 +113,20 @@ hand or use the same address for both.
    - Update Contact, Canonical, Policy, Acknowledgments to the new URL.
    - Bump Expires to ~12 months out, formatted YYYY-MM-DDTHH:MM:SSZ.
 
-4. public/site.webmanifest
-   - Update name, short_name, theme_color, background_color.
+4. Web manifest — NO direct edits needed.
+   - The manifest is auto-generated from siteConfig by src/app/manifest.ts
+     and served at /manifest.webmanifest at build time. Editing
+     siteConfig.{name, shortDescription, themeColor} (step 1) updates it.
+   - DO NOT add a static public/site.webmanifest back — it was deleted on
+     purpose so the values can't drift from siteConfig.
 
 5. public/Images/ and public/Svgs/
    - Replace branded assets. KEEP existing filenames where possible so the
      LCP preload in layout.tsx still hits a real file.
+   - Header logo: src/components/header/index.tsx still hardcodes an image
+     from a third-party URL (freeforcharity.org WordPress). Replace it
+     with a self-hosted asset under /Images/ or /Svgs/ and use
+     assetPath().
 
 6. src/data/{faqs,team,testimonials}.ts
    - Replace example content with the charity's real data.

--- a/TEMPLATE_SETUP_CHECKLIST.md
+++ b/TEMPLATE_SETUP_CHECKLIST.md
@@ -99,24 +99,45 @@ Create ruleset named "Protect Main":
 
 ## Customize Content and Branding
 
-### Organization Information
+### Organization Information (use `siteConfig`, NOT find-and-replace)
 
-- [ ] Search and replace "Free For Charity" with your org name
-- [ ] Search and replace EIN "46-2471893" with your EIN
-- [ ] Search and replace "ffcworkingsite1.org" with your domain
+- [ ] Edit `src/lib/site.config.ts` — sets the name, URL, description,
+      twitter handle, contact email, social links, theme color
+      everywhere they're consumed (title, OG/Twitter, footer, 404,
+      manifest, sitemap, robots, security headers)
+- [ ] Run `npm run check:drift` after editing — the placeholder-URL
+      and CSP-sync rules will flag anything still pointing at
+      `ffcworkingsite1.org` or out of sync
+- [ ] Update the EIN, mailing addresses, phone number, and GuideStar
+      profile link still hardcoded in `src/components/footer/index.tsx`
+      (these are not in siteConfig yet)
 
 ### Contact Information
 
-- [ ] Update `src/components/footer/index.tsx` - Footer contact
-- [ ] Update `SECURITY.md` - Security contact
-- [ ] Update `CODE_OF_CONDUCT.md` - Conduct reporting contact
-- [ ] Update `SUPPORT.md` - Support resources
+- [ ] `siteConfig.contactEmail` drives the footer e-mail link
+- [ ] Update `public/.well-known/security.txt` `Contact:` line (RFC
+      9116 requires it on the file itself; drift check warns on stale)
+- [ ] Update `SECURITY.md` — Security contact
+- [ ] Update `CODE_OF_CONDUCT.md` — Conduct reporting contact
+- [ ] Update `SUPPORT.md` — Support resources
 
 ### Branding Assets
 
-- [ ] Replace `/public/logo.svg` with your logo
-- [ ] Replace `/public/favicon.ico` with your favicon
-- [ ] Update Open Graph images (if present)
+- [ ] Replace `public/favicon.ico`, `public/icon.png`,
+      `public/apple-icon.png`, `public/android-chrome-{192,512}.png`,
+      and `public/web-app-manifest-512x512.png` with the charity's
+      branded assets (KEEP the filenames so layout.tsx and manifest.ts
+      pick them up automatically)
+- [ ] Replace the header logo: `src/components/header/index.tsx`
+      currently hardcodes an external `https://freeforcharity.org/...`
+      WordPress URL. Self-host a logo under `public/Images/` and use
+      `assetPath('/Images/your-logo.png')` instead.
+- [ ] Replace the OG / Twitter card image — `layout.tsx` references
+      `/web-app-manifest-512x512.png` (a square 512×512). For proper
+      social cards, drop a 1200×630 image at the same filename or
+      update both layout.tsx references to point at a new asset.
+- [ ] Replace branded images and SVGs under `public/Images/` and
+      `public/Svgs/`
 - [ ] Update color scheme in `src/app/globals.css`
 - [ ] Update fonts in `src/app/layout.tsx` (if needed)
 

--- a/__tests__/lib/site.config.test.ts
+++ b/__tests__/lib/site.config.test.ts
@@ -34,10 +34,17 @@ describe('siteUrl', () => {
   })
 
   it('strips a trailing slash from siteConfig.url before joining', () => {
-    // The function reads siteConfig.url at call time. Confirm that the
-    // helper does not double-up trailing slashes if the caller's path
-    // already begins with one (which it must).
-    expect(siteUrl('/x').endsWith('//x')).toBe(false)
+    // Mutate siteConfig.url to actually exercise the trailing-slash
+    // branch in siteUrl(). Without this the previous assertion was
+    // testing the no-slash default path and giving false confidence.
+    const original = siteConfig.url
+    try {
+      siteConfig.url = original.replace(/\/?$/, '/') // ensure trailing slash
+      expect(siteUrl('/x')).toBe(original.replace(/\/$/, '') + '/x')
+      expect(siteUrl('/x').includes('//x')).toBe(false)
+    } finally {
+      siteConfig.url = original
+    }
   })
 })
 

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -285,7 +285,11 @@ async function checkSiteConfigExists() {
 // CSP directives that are honored in <meta http-equiv> AND in HTTP headers.
 // We diff each of these between public/_headers and src/app/layout.tsx so
 // the two stay in lockstep on third-party origins.
+// Includes the security-floor directives (default-src, object-src, base-uri)
+// alongside the third-party allowlists — a one-sided tightening of object-src
+// or base-uri would silently degrade one host while leaving the other safe.
 const SYNCED_CSP_DIRECTIVES = [
+  'default-src',
   'script-src',
   'style-src',
   'img-src',
@@ -294,6 +298,8 @@ const SYNCED_CSP_DIRECTIVES = [
   'frame-src',
   'media-src',
   'form-action',
+  'object-src',
+  'base-uri',
 ]
 
 function extractCspDirectives(policy) {
@@ -369,7 +375,44 @@ async function checkCspSync() {
   }
 }
 
+async function checkSiteConfigUrl() {
+  const cfgPath = join(ROOT, 'src', 'lib', 'site.config.ts')
+  let cfg
+  try {
+    cfg = await readFile(cfgPath, 'utf8')
+  } catch {
+    return // missing config handled in checkSiteConfigExists
+  }
+  const m = cfg.match(/url:\s*['"]([^'"]+)['"]/)
+  if (!m) return
+  const raw = m[1]
+  if (!raw.startsWith('https://')) {
+    errors.push(
+      `src/lib/site.config.ts: siteConfig.url "${raw}" must start with "https://". ` +
+        `metadataBase = new URL(siteConfig.url) will throw at build time otherwise.`
+    )
+  }
+  if (raw.endsWith('/')) {
+    errors.push(
+      `src/lib/site.config.ts: siteConfig.url "${raw}" must not end with "/". ` +
+        `The siteUrl helper assumes no trailing slash; OG/Twitter card URLs will be malformed.`
+    )
+  }
+  try {
+    const u = new URL(raw)
+    if (u.pathname !== '/' && u.pathname !== '') {
+      errors.push(
+        `src/lib/site.config.ts: siteConfig.url "${raw}" should be the bare origin (no path). ` +
+          `Move any path component into the helpers that consume it.`
+      )
+    }
+  } catch {
+    errors.push(`src/lib/site.config.ts: siteConfig.url "${raw}" is not a parseable URL.`)
+  }
+}
+
 await checkSiteConfigExists()
+await checkSiteConfigUrl()
 await checkKebabCaseRoutes()
 await checkAssetPathUsage()
 await checkSecrets()


### PR DESCRIPTION
## Summary

Follow-up to the six PRs that landed today (#257-#261, #274). A fresh cumulative review surfaced 5 actionable gaps between what the merged docs/code now claim and what's actually shipped — all closed here.

| Area | Before | After |
|------|--------|-------|
| `SYNCED_CSP_DIRECTIVES` | 8 directives | Adds `default-src`, `object-src`, `base-uri` — `tests/head-meta.spec.ts` (from #274) asserts `object-src` in the meta CSP but drift check wasn't enforcing parity |
| `siteConfig.url` validation | Cryptic `TypeError [ERR_INVALID_URL]` at build time | New `checkSiteConfigUrl` rule: errors on missing https, trailing slash, path component, or unparseable URL — the four common volunteer footguns |
| Trailing-slash test | Asserted default no-slash value didn't double-up (false confidence) | Actually mutates `siteConfig.url` to force the trailing-slash branch in `siteUrl()` |
| `AGENTS.md` + `CLAUDE.md` pre-commit | Lint → test → build → e2e | Adds `npm run check:drift` between lint and test (the husky hook and CI workflow have been running it since #257) |
| `README.md` customization prompt | Step 4: "edit `public/site.webmanifest`" | "No direct edits — manifest auto-generated by `src/app/manifest.ts`" + DO-NOT note about adding the static file back |
| `TEMPLATE_SETUP_CHECKLIST.md` | "Search and replace 'Free For Charity'" + "Replace /public/logo.svg" (nonexistent) | Directs volunteers to `siteConfig.ts` + explicit guidance to self-host the header logo (currently external), replace OG image (1200×630), keep favicon/manifest filenames |
| `.claude/agents/site-health.md` | Pinned `/site.webmanifest` only (deleted by #259) | Tries `/manifest.webmanifest` (current) first, falls back to `/site.webmanifest` (legacy), checks content-type to detect SPA fallback |

## Verification

- `npm run format` clean
- `npm run lint` — 0 errors
- `npm run check:drift` — 0 errors (including the new `checkSiteConfigUrl` and broader CSP-sync rules)
- `npm test` — 41/41 (the fixed trailing-slash test actually exercises the regex now)
- `npm run build` — clean

## Cross-PR independence

This branch is off the latest main (post-#259, #274). No conflicts expected since the only file shared with in-flight branches is `scripts/check-drift.mjs` and there are no other PRs touching it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G73s7idxoHDUsTPyE8tF8h)_