### PR TITLE
chore: remove redundant BlogCard.tsx entry from tsconfig include

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "src/components/UI/BlogCard.tsx",
     ".next/dev/types/**/*.ts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary

Removes a redundant `tsconfig.json` `include` entry that hardcoded `src/components/UI/BlogCard.tsx`. The actual directory is lowercase `ui/`, and the preceding `**/*.tsx` glob already covers the file — the entry was both wrong and unnecessary.

## Why it matters

Case-insensitive filesystems (macOS, Windows) hide the bug; case-sensitive Linux CI containers can break on it. Removing the line keeps tsconfig internally consistent and avoids confusion for IDEs / refactor tools.

## Verification

- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings (unrelated)
- `npm test` — 41/41 passed
- `npm run build` — 13 pages exported, TypeScript clean
- `npm run test:e2e` — 65 passed, 1 skipped, 5 pre-existing failures (GTM env config + external Microsoft Forms iframe — unrelated)
- Husky pre-commit hooks — green

## Test plan

- [x] `tsconfig.json` is internally consistent (no `UI` casing references that don't exist on disk)
- [x] `npm run build` and `npm test` green
- [x] No new files referenced incorrectly

Fixes #287
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_