### PR TITLE
test: add unit tests for src/lib/fonts.ts

### DIFF
--- a/__tests__/lib/fonts.test.ts
+++ b/__tests__/lib/fonts.test.ts
@@ -1,0 +1,127 @@
+// Mock next/font/google so it echoes the call's configuration back out.
+// next/jest's default mock returns literal "variable", which strips the
+// data we care about (the configured CSS variable name).
+jest.mock('next/font/google', () => {
+  const echo = (config: Record<string, unknown>) => ({
+    className: 'mock-className',
+    style: { fontFamily: 'mock-family' },
+    variable: config.variable,
+    weight: config.weight,
+    subsets: config.subsets,
+    display: config.display,
+  })
+  return {
+    Open_Sans: echo,
+    Lato: echo,
+    Raleway: echo,
+    Faustina: echo,
+    Cantata_One: echo,
+    Fauna_One: echo,
+    Montserrat: echo,
+    Cinzel: echo,
+  }
+})
+
+import {
+  openSans,
+  lato,
+  raleway,
+  faustina,
+  cantataOne,
+  faunaOne,
+  montserrat,
+  cinzel,
+} from '../../src/lib/fonts'
+
+describe('fonts module exports', () => {
+  const allFonts = {
+    openSans,
+    lato,
+    raleway,
+    faustina,
+    cantataOne,
+    faunaOne,
+    montserrat,
+    cinzel,
+  } as const
+
+  it('exports a defined font object for every named Google font', () => {
+    for (const [name, font] of Object.entries(allFonts)) {
+      expect(font).toBeDefined()
+      expect(typeof font).toBe('object')
+      expect(font).not.toBeNull()
+      expect({ name, hasKeys: Object.keys(font).length > 0 }).toEqual({
+        name,
+        hasKeys: true,
+      })
+    }
+  })
+
+  it('exposes a CSS variable name on every font matching --font-<kebab-name>', () => {
+    const expected: Record<keyof typeof allFonts, string> = {
+      openSans: '--font-open-sans',
+      lato: '--font-lato',
+      raleway: '--font-raleway',
+      faustina: '--font-faustina',
+      cantataOne: '--font-cantata-one',
+      faunaOne: '--font-fauna-one',
+      montserrat: '--font-montserrat',
+      cinzel: '--font-cinzel',
+    }
+
+    for (const [name, font] of Object.entries(allFonts)) {
+      const variable = (font as { variable?: string }).variable
+      expect({ name, variable }).toEqual({
+        name,
+        variable: expected[name as keyof typeof allFonts],
+      })
+    }
+  })
+
+  it('configures the latin subset and swap display for every font', () => {
+    for (const [name, font] of Object.entries(allFonts)) {
+      const cfg = font as { subsets?: string[]; display?: string }
+      expect({ name, subsets: cfg.subsets, display: cfg.display }).toEqual({
+        name,
+        subsets: ['latin'],
+        display: 'swap',
+      })
+    }
+  })
+
+  it('configures weight for each font matching the original definition', () => {
+    const expectedWeight: Record<keyof typeof allFonts, string | string[]> = {
+      openSans: ['400', '500', '600', '700', '800'],
+      lato: ['400', '700'],
+      raleway: ['400', '500', '600', '700'],
+      faustina: ['400', '500', '600', '700'],
+      cantataOne: '400',
+      faunaOne: '400',
+      montserrat: ['400', '500', '600', '700'],
+      cinzel: ['400', '500', '600', '700'],
+    }
+
+    for (const [name, font] of Object.entries(allFonts)) {
+      const weight = (font as { weight?: string | string[] }).weight
+      expect({ name, weight }).toEqual({
+        name,
+        weight: expectedWeight[name as keyof typeof allFonts],
+      })
+    }
+  })
+
+  it('exports exactly the eight expected font instances', () => {
+    expect(Object.keys(allFonts).sort()).toEqual(
+      [
+        'cantataOne',
+        'cinzel',
+        'faunaOne',
+        'faustina',
+        'lato',
+        'montserrat',
+        'openSans',
+        'raleway',
+      ].sort()
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Adds the missing unit-test coverage for `src/lib/fonts.ts`. Both other `src/lib/*.ts` files (`assetPath.ts`, `site.config.ts`) already had tests under `__tests__/lib/`; this closes the last gap in the utility layer.

## What's covered

5 cases asserting:

- every named export is a defined object
- each font carries the configured `--font-<kebab-name>` CSS variable
- each is configured with the `latin` subset and `swap` display strategy
- weight values match the original definition
- the module exports exactly the 8 expected named instances

## A note on mocking

`next/jest`'s default mock for `next/font/google` returns the literal string `"variable"` for every config field, which would silently mask regressions in our configured variable names. The test installs a small `jest.mock` that echoes the caller's config back, so assertions can reach the real configuration.

## Verification

- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings (unrelated)
- `npm test` — 46/46 passed (was 41, +5 new)
- `npm run build` — 13 pages exported
- `npm run test:e2e` — 64 passed, 1 skipped, 6 pre-existing env-driven failures (GTM + external iframe — unrelated)
- Husky pre-commit hooks — green

## Test plan

- [x] Test file exists at `__tests__/lib/fonts.test.ts`
- [x] Asserts the expected font objects expose the expected variable names / weights
- [x] `npm test` green
- [x] No source changes

Fixes #275
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_