### PR TITLE
feat(seo): emit Organization (NGO) JSON-LD on the homepage

### DIFF
--- a/__tests__/components/seo/OrganizationSchema.test.tsx
+++ b/__tests__/components/seo/OrganizationSchema.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import OrganizationSchema, {
+  buildOrganizationSchema,
+} from '../../../src/components/seo/OrganizationSchema'
+import { siteConfig } from '../../../src/lib/site.config'
+
+describe('OrganizationSchema', () => {
+  it('builds a schema.org NGO object with values from siteConfig', () => {
+    const schema = buildOrganizationSchema()
+
+    expect(schema['@context']).toBe('https://schema.org')
+    expect(schema['@type']).toBe('NGO')
+    expect(schema.name).toBe(siteConfig.name)
+    expect(schema.description).toBe(siteConfig.description)
+
+    expect(typeof schema.url).toBe('string')
+    expect(schema.url as string).toMatch(/^https:\/\//)
+
+    expect(typeof schema.logo).toBe('string')
+    expect(schema.logo as string).toMatch(/^https:\/\//)
+  })
+
+  it('includes social profiles as sameAs when configured', () => {
+    const schema = buildOrganizationSchema()
+    if (siteConfig.social.some((s) => s.href.trim().length > 0)) {
+      expect(Array.isArray(schema.sameAs)).toBe(true)
+      const sameAs = schema.sameAs as string[]
+      for (const s of siteConfig.social) {
+        if (s.href.trim().length > 0) {
+          expect(sameAs).toContain(s.href.trim())
+        }
+      }
+    }
+  })
+
+  it('renders a single application/ld+json script block whose JSON parses', () => {
+    const { container } = render(<OrganizationSchema />)
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]')
+    expect(scripts.length).toBe(1)
+    const text = scripts[0].textContent ?? ''
+    expect(text.length).toBeGreaterThan(0)
+    const parsed = JSON.parse(text) as Record<string, unknown>
+    expect(parsed.name).toBe(siteConfig.name)
+    expect(parsed['@type']).toBe('NGO')
+  })
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 // import HomePage from './Home/page'
 import HomePage from '@/app/home-page'
+import OrganizationSchema from '@/components/seo/OrganizationSchema'
 
 const page = () => {
   return (
     <div>
+      <OrganizationSchema />
       {/* <HomePage /> */}
       <HomePage />
     </div>

--- a/src/components/seo/OrganizationSchema.tsx
+++ b/src/components/seo/OrganizationSchema.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { siteConfig, siteUrl } from '@/lib/site.config'
+import { assetPath } from '@/lib/assetPath'
+
+/**
+ * Builds the schema.org NGO JSON-LD object for this site. Pulls every value
+ * from `siteConfig` so a fork only edits one file. Exported separately so
+ * it can be asserted in unit tests without rendering.
+ */
+export function buildOrganizationSchema(): Record<string, unknown> {
+  const sameAs = siteConfig.social.map((s) => s.href.trim()).filter((href) => href.length > 0)
+
+  const schema: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'NGO',
+    name: siteConfig.name,
+    description: siteConfig.description,
+    url: siteUrl('/'),
+    logo: siteUrl(assetPath('/web-app-manifest-512x512.png')),
+  }
+
+  if (sameAs.length > 0) {
+    schema.sameAs = sameAs
+  }
+
+  if (siteConfig.contactEmail) {
+    schema.email = siteConfig.contactEmail
+  }
+
+  return schema
+}
+
+/**
+ * Emits a single <script type="application/ld+json"> block carrying an NGO
+ * Organization schema for the site. Render once on the homepage so search
+ * engines, knowledge-panel matchers, and assistant integrations have a
+ * canonical machine-readable identity for the org.
+ *
+ * Server component — no client runtime cost.
+ */
+export default function OrganizationSchema() {
+  const schema = buildOrganizationSchema()
+  return (
+    <script
+      type="application/ld+json"
+      // Stable JSON output: stringify with no whitespace to avoid layout
+      // shift and keep the payload small. dangerouslySetInnerHTML is the
+      // standard pattern for inline JSON-LD per the Next.js docs.
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

Adds Organization (NGO) JSON-LD structured data to the homepage. The repo previously had zero `application/ld+json` blocks. NGO/Organization schema powers rich results in Google search, knowledge-panel matching, and AI-assistant integrations — everything required already lives in `siteConfig`, so this is pure wiring.

## What's wired

- New server component: `src/components/seo/OrganizationSchema.tsx`
  - Exports `buildOrganizationSchema()` (testable) and a default React component
  - Reads `name`, `description`, social profiles, and contact email from `siteConfig`
  - Builds canonical URLs via the existing `siteUrl()` helper
  - References the logo via the existing `assetPath()` helper (GitHub Pages basePath safe)
- Mounted in `src/app/page.tsx` (NOT `src/app/layout.tsx`, per the issue's coordination note about head metadata being touched by #274)
- New unit test: `__tests__/components/seo/OrganizationSchema.test.tsx` — 3 cases asserting the schema parses, has the expected `@type`, name, and pulls social profiles from siteConfig

## Sample emitted JSON-LD

Verified in the built `out/index.html`:

```json
{
  "@context": "https://schema.org",
  "@type": "NGO",
  "name": "Free For Charity",
  "description": "Free For Charity connects students, professionals, and businesses with nonprofits to reduce costs and increase revenues—putting more resources back into their missions.",
  "url": "https://ffcworkingsite1.org/",
  "logo": "https://ffcworkingsite1.org/web-app-manifest-512x512.png",
  "sameAs": [
    "https://www.facebook.com/freeforcharity",
    "https://x.com/freeforcharity1",
    "https://www.linkedin.com/company/freeforcharity/",
    "https://github.com/FreeForCharity/FFC_Single_Page_Template"
  ],
  "email": "security@freeforcharity.org"
}
```

## Verification

- `grep "application/ld+json" out/index.html` — one block present in the built output (was zero on main)
- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings
- `npm test` — 44/44 passed (was 41, +3 new)
- `npm run build` — 13 pages exported
- `npm run test:e2e` — 64 passed, 1 skipped, 6 pre-existing env failures (unrelated)
- `npm run check:drift` — green
- Husky pre-commit hooks — green
- Manually validated with Google's [Rich Results Test](https://search.google.com/test/rich-results) is recommended after deploy

## Test plan

- [x] Page source on `/` contains a valid JSON-LD block
- [x] Block uses `@type: NGO`
- [x] All fields originate from `siteConfig` — no hardcoded data
- [x] Unit test asserts the block parses as JSON and contains `name === siteConfig.name`
- [x] `src/app/layout.tsx` is NOT modified (per coordination with #274)

Fixes #284
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_