### PR TITLE
feat(seo): add sitemap drift-guard test and normalize policy priorities

### DIFF
--- a/__tests__/app/sitemap.test.ts
+++ b/__tests__/app/sitemap.test.ts
@@ -1,0 +1,73 @@
+import fs from 'fs'
+import path from 'path'
+import sitemap, { routes } from '../../src/app/sitemap'
+import { siteConfig } from '../../src/lib/site.config'
+
+const APP_DIR = path.resolve(__dirname, '..', '..', 'src', 'app')
+
+// Files under src/app/ that have a `page.tsx` but are NOT public web routes
+// (error boundaries, manifest, etc.) — exclude these from the route audit.
+const NOT_A_PUBLIC_ROUTE = new Set<string>(['error.tsx', 'not-found.tsx'])
+
+/**
+ * Walk src/app/ and return every directory that owns a page.tsx, expressed
+ * as the URL path the route would render at ('/foo', '/foo/bar', '/').
+ */
+function discoverPublicRoutes(dir: string, prefix = ''): string[] {
+  const out: string[] = []
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name === 'page.tsx') {
+      out.push(prefix === '' ? '/' : prefix)
+    }
+    if (entry.isDirectory()) {
+      // Skip Next.js conventions that aren't a separate URL segment.
+      if (entry.name.startsWith('_') || entry.name.startsWith('.')) continue
+      // Skip any directory whose name itself is in the not-a-route allowlist.
+      if (NOT_A_PUBLIC_ROUTE.has(entry.name)) continue
+      out.push(...discoverPublicRoutes(path.join(dir, entry.name), `${prefix}/${entry.name}`))
+    }
+  }
+
+  return out
+}
+
+describe('sitemap.ts', () => {
+  it('lists every page.tsx route exactly once', () => {
+    const discovered = discoverPublicRoutes(APP_DIR).sort()
+    const sitemapPaths = routes.map((r) => r.path).sort()
+
+    expect(sitemapPaths).toEqual(discovered)
+  })
+
+  it('contains no duplicate path entries', () => {
+    const paths = routes.map((r) => r.path)
+    const unique = new Set(paths)
+    expect(paths.length).toBe(unique.size)
+  })
+
+  it('emits absolute URLs prefixed with siteConfig.url', () => {
+    const entries = sitemap()
+    for (const e of entries) {
+      expect(typeof e.url).toBe('string')
+      expect(e.url.startsWith(siteConfig.url.replace(/\/$/, ''))).toBe(true)
+    }
+  })
+
+  it('uses priority 1.0 for the root route only', () => {
+    const root = routes.find((r) => r.path === '/')
+    expect(root?.priority).toBe(1.0)
+    const others = routes.filter((r) => r.path !== '/')
+    for (const r of others) {
+      expect(r.priority).toBeLessThan(1.0)
+    }
+  })
+
+  it('keeps every priority within the [0, 1] range', () => {
+    for (const r of routes) {
+      expect(r.priority).toBeGreaterThanOrEqual(0)
+      expect(r.priority).toBeLessThanOrEqual(1)
+    }
+  })
+})

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,12 +11,24 @@ type SitemapEntry = {
 
 // Routes that have a `src/app/<slug>/page.tsx`. Add new top-level routes here
 // so they appear in the sitemap. Sub-routes can be added with their full path.
-const routes: readonly SitemapEntry[] = [
+//
+// The unit test in __tests__/app/sitemap.test.ts diffs this list against the
+// real `src/app/**` filesystem: if a `page.tsx` is added without a matching
+// entry here the test fails, so the sitemap can never silently fall behind.
+//
+// Priority schema:
+//   1.0 — root
+//   0.8 — primary content pages (about, donate, volunteer, contact, programs)
+//   0.5 — secondary content pages
+//   0.2 — policy / legal pages
+//
+// changeFrequency: 'monthly' for content pages, 'yearly' for policy pages.
+export const routes: readonly SitemapEntry[] = [
   { path: '/', changeFrequency: 'weekly', priority: 1.0 },
-  { path: '/privacy-policy', changeFrequency: 'yearly', priority: 0.3 },
-  { path: '/cookie-policy', changeFrequency: 'yearly', priority: 0.3 },
-  { path: '/terms-of-service', changeFrequency: 'yearly', priority: 0.3 },
-  { path: '/donation-policy', changeFrequency: 'yearly', priority: 0.3 },
+  { path: '/privacy-policy', changeFrequency: 'yearly', priority: 0.2 },
+  { path: '/cookie-policy', changeFrequency: 'yearly', priority: 0.2 },
+  { path: '/terms-of-service', changeFrequency: 'yearly', priority: 0.2 },
+  { path: '/donation-policy', changeFrequency: 'yearly', priority: 0.2 },
   { path: '/free-for-charity-donation-policy', changeFrequency: 'yearly', priority: 0.2 },
   { path: '/vulnerability-disclosure-policy', changeFrequency: 'yearly', priority: 0.2 },
   { path: '/security-acknowledgements', changeFrequency: 'monthly', priority: 0.2 },


### PR DESCRIPTION
## Summary

Scope reconciliation noted on the issue thread: this single-page template only has 8 `page.tsx` routes, and all 8 are already enumerated in `src/app/sitemap.ts`. The "missing" routes the issue body called out (`/about-us`, `/donate`, `/volunteer`, `/contact-us`) are anchor sections under `src/components/`, not separate routes.

What this PR delivers is the **remaining value from the issue**:

1. A **drift-guard unit test** (`__tests__/app/sitemap.test.ts`) that walks `src/app/` at test time and asserts every directory carrying a `page.tsx` is represented exactly once in `sitemap.ts`. New routes that someone forgets to enumerate will fail the suite.
2. **Priority normalization** — policy/legal pages were a mix of `0.2` and `0.3`; they're now all `0.2` per the schema the issue spelled out.
3. **`routes` is now exported** so the test can assert against the source of truth.
4. An expanded comment block in `sitemap.ts` documenting the priority schema and the existence of the drift guard.

## Verification

- Built `/sitemap.xml` lists every public route exactly once — 8 `<url>` entries (one per `page.tsx`)
- `npm test` — 46/46 passed (was 41, +5 new sitemap cases)
- `npm run build` — 13 pages exported
- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings
- `npm run test:e2e` — 66 passed, 1 skipped, 4 pre-existing env failures (GTM — unrelated)
- `npm run check:drift` — green
- Husky pre-commit hooks — green

## Test plan

- [x] Built `/sitemap.xml` lists every public route exactly once
- [x] Test guards against future drift — a new `page.tsx` without a matching entry fails the suite
- [x] `npm run build` and `npm test` green
- [x] `robots.ts` was not changed (it already does what it should — references the sitemap and allows all)

Fixes #285
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_