### PR TITLE
ci: wire linkinator into CI as a soft-fail post-build link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,32 @@ jobs:
             .next/
             out/
           retention-days: 7
+
+  link-check:
+    name: Link check (soft-fail)
+    runs-on: ubuntu-latest
+    # Soft-fail today so we can see what linkinator surfaces without
+    # blocking merges. Flip to hard-fail once the noise is understood
+    # — tracked as a follow-up to #289.
+    continue-on-error: true
+    # Kept as a separate job (not inside test-and-build) so it does not
+    # multiply across the Playwright shard matrix introduced by #133.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js site
+        run: npm run build
+
+      - name: Check for broken links
+        run: npm run check-links

--- a/.linkinatorrc.json
+++ b/.linkinatorrc.json
@@ -1,7 +1,6 @@
 {
   "skip": [
     "^https://github.com/(?!FreeForCharity/FFC_Single_Page_Template).*",
-    "^http://localhost.*",
     "^https://www.linkedin.com/.*",
     "^https://twitter.com/.*",
     "^https://www.facebook.com/.*",


### PR DESCRIPTION
## Summary

Wires linkinator into CI as a separate, soft-failing post-build job. Also fixes a pre-existing bug in `.linkinatorrc.json` that made `npm run check-links` report "0 links scanned" regardless of input.

## What changed

### `.github/workflows/ci.yml`

Adds a new `link-check` job that:

- runs in parallel with the existing `test-and-build` job (no dependency, so failures here don't gate other CI)
- does its own `actions/checkout@v6` + `setup-node@v6` + `npm ci` + `npm run build`
- runs `npm run check-links` against `./out`
- has `continue-on-error: true` so broken links surface in the Actions tab without blocking merges

Kept as a separate job (not a step inside `test-and-build`) so it does not multiply across the Playwright shard matrix that #133 is introducing.

### `.linkinatorrc.json`

The skip rule `^http://localhost.*` was matching linkinator's own internal HTTP server URL (linkinator serves the static directory over localhost to crawl it). The crawl was being terminated at the seed URL, returning "Successfully scanned 0 links" even when the directory was full of content. Removed that rule — a literal `http://localhost` URL in built HTML would be a real bug worth catching anyway.

## What linkinator finds today (will be visible in the soft-fail job)

After the config fix, linkinator scans 74 links and surfaces 8 issues on `main`:

- 7 are static-export trailing-slash false positives (`/donation-policy` resolves to a directory; linkinator doesn't auto-rewrite to `index.html`). To be addressed in a separate fast-follow PR.
- 1 is `https://ffcsites.org/videos/mission-video.mp4`, which is the same issue #280 already tracks.

Soft-fail keeps merges flowing while these are triaged.

## Verification

- `node -e yaml.load(...)` — `.github/workflows/ci.yml` parses cleanly
- `npm run check-links` locally — runs, surfaces 8 issues (was: silently "0 links")
- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings
- `npm test` — 41/41 passed
- `npm run build` — 13 pages exported
- `npm run test:e2e` — 65 passed, 1 skipped, 5 pre-existing env failures (unrelated)
- `npm run check:drift` — green
- Husky pre-commit hooks — green

## Coordination

- **#133 (Playwright sharding)** — kept the new job separate from `test-and-build` so the new job won't multiply across shards
- **#249 (Pages action baseline)** — only edits `ci.yml`, not `deploy.yml`/`lighthouse.yml`; merge whichever lands later as a no-op rebase

## Test plan

- [x] Job runs on every PR
- [x] Output visible in the Actions tab
- [x] Linkinator surfaces broken links (verified locally: 8 issues reported on `main`)

Fixes #289
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_