### PR TITLE
test: add unit tests for top 5 untested UI components

### DIFF
--- a/__tests__/components/ui/AnimatedNumber.test.tsx
+++ b/__tests__/components/ui/AnimatedNumber.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+// framer-motion uses IntersectionObserver (via useInView) and DOM measurements
+// that jsdom doesn't provide. Mock the specific hooks the component imports
+// so the static (reduced-motion) render path is exercised end-to-end.
+jest.mock('framer-motion', () => {
+  return {
+    useReducedMotion: () => true,
+    useInView: () => true,
+    useMotionValue: (initial: number) => ({
+      set: jest.fn(),
+      get: () => initial,
+      on: () => () => undefined,
+    }),
+    useSpring: (mv: { on: (event: string, cb: (latest: number) => void) => () => void }) => mv,
+    motion: new Proxy(
+      {},
+      {
+        get: () => {
+          // Return a passthrough component for any motion.<tag> lookup.
+          const Pass = ({ children, ...rest }: React.PropsWithChildren<Record<string, unknown>>) =>
+            React.createElement('span', rest, children)
+          return Pass
+        },
+      }
+    ),
+  }
+})
+
+import AnimatedNumber from '../../../src/components/ui/AnimatedNumber'
+
+describe('AnimatedNumber', () => {
+  it('renders the target value statically when reduced motion is preferred', () => {
+    render(<AnimatedNumber value={42} />)
+    expect(screen.getByText('42')).toBeInTheDocument()
+  })
+
+  it('applies className when provided', () => {
+    const { container } = render(<AnimatedNumber value={7} className="text-xl" />)
+    expect(container.querySelector('.text-xl')).not.toBeNull()
+  })
+
+  it('applies id when provided', () => {
+    const { container } = render(<AnimatedNumber value={3} id="impact-stat-1" />)
+    expect(container.querySelector('#impact-stat-1')).not.toBeNull()
+  })
+
+  it('handles a value of zero', () => {
+    render(<AnimatedNumber value={0} />)
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/ui/ApplicationFormButton.test.tsx
+++ b/__tests__/components/ui/ApplicationFormButton.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ApplicationFormButton from '../../../src/components/ui/ApplicationFormButton'
+
+describe('ApplicationFormButton', () => {
+  it('renders with the default button label when no text prop is provided', () => {
+    render(<ApplicationFormButton />)
+    expect(
+      screen.getByRole('button', { name: 'Apply to Become a Supported Charity' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders with a custom button label when text prop is provided', () => {
+    render(<ApplicationFormButton text="Apply now" />)
+    expect(screen.getByRole('button', { name: 'Apply now' })).toBeInTheDocument()
+  })
+
+  it('does not render the modal until the button is clicked', () => {
+    render(<ApplicationFormButton />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('opens the dialog when the button is clicked and shows the iframe with the default form URL', () => {
+    render(<ApplicationFormButton />)
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to Become a Supported Charity' }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+
+    const iframe = dialog.querySelector('iframe')
+    expect(iframe).not.toBeNull()
+    expect(iframe).toHaveAttribute('src', 'https://forms.office.com/r/vePxGq6JqG')
+    expect(iframe).toHaveAttribute('title', 'Charity Application Form')
+  })
+
+  it('uses the formUrl prop when provided', () => {
+    render(<ApplicationFormButton formUrl="https://forms.office.com/r/customId" />)
+    fireEvent.click(screen.getByRole('button'))
+    const iframe = screen.getByRole('dialog').querySelector('iframe')
+    expect(iframe).toHaveAttribute('src', 'https://forms.office.com/r/customId')
+  })
+
+  it('closes the dialog when the close button is clicked', () => {
+    render(<ApplicationFormButton />)
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to Become a Supported Charity' }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close application form' }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/__tests__/components/ui/BlogCard.test.tsx
+++ b/__tests__/components/ui/BlogCard.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import BlogCard from '../../../src/components/ui/BlogCard'
+
+describe('BlogCard', () => {
+  it('renders the heading and description', () => {
+    render(<BlogCard heading="Headline copy" description="Body copy" />)
+    expect(screen.getByRole('heading', { level: 3, name: 'Headline copy' })).toBeInTheDocument()
+    expect(screen.getByText('Body copy')).toBeInTheDocument()
+  })
+
+  it('omits the date paragraph when no date prop is provided', () => {
+    render(<BlogCard heading="Headline" description="Body" />)
+    // Date paragraph has the orange-text class id; absence is asserted by text.
+    expect(screen.queryByText(/202[0-9]/)).toBeNull()
+  })
+
+  it('renders the date when provided', () => {
+    render(<BlogCard heading="Headline" description="Body" date="May 24, 2026" />)
+    expect(screen.getByText('May 24, 2026')).toBeInTheDocument()
+  })
+
+  it('wraps the heading in a link when href is provided', () => {
+    render(<BlogCard heading="Click me" description="Body" href="https://example.org" />)
+    const link = screen.getByRole('link', { name: 'Click me' })
+    expect(link).toHaveAttribute('href', 'https://example.org')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('does not render an image when imageUrl is not provided', () => {
+    const { container } = render(<BlogCard heading="No image" description="Body" />)
+    expect(container.querySelector('img')).toBeNull()
+  })
+})

--- a/__tests__/components/ui/ResultCard.test.tsx
+++ b/__tests__/components/ui/ResultCard.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+// Reuse the same framer-motion mock pattern as AnimatedNumber.test.tsx —
+// ResultCard renders AnimatedNumber for numeric titles, and that pulls in
+// IntersectionObserver-backed hooks that jsdom doesn't provide.
+jest.mock('framer-motion', () => {
+  return {
+    useReducedMotion: () => true,
+    useInView: () => true,
+    useMotionValue: (initial: number) => ({
+      set: jest.fn(),
+      get: () => initial,
+      on: () => () => undefined,
+    }),
+    useSpring: (mv: { on: (event: string, cb: (latest: number) => void) => () => void }) => mv,
+    motion: new Proxy(
+      {},
+      {
+        get: () => {
+          const Pass = ({ children, ...rest }: React.PropsWithChildren<Record<string, unknown>>) =>
+            React.createElement('span', rest, children)
+          return Pass
+        },
+      }
+    ),
+  }
+})
+
+import ResultCard from '../../../src/components/ui/ResultCard'
+
+describe('ResultCard', () => {
+  it('renders the title and description when title is non-numeric', () => {
+    render(<ResultCard title="N/A" description="No data this year" />)
+    expect(screen.getByText('N/A')).toBeInTheDocument()
+    expect(screen.getByText('No data this year')).toBeInTheDocument()
+  })
+
+  it('wraps a numeric title in AnimatedNumber (renders the parsed number)', () => {
+    render(<ResultCard title="125" description="Volunteers" />)
+    expect(screen.getByText('125')).toBeInTheDocument()
+    expect(screen.getByText('Volunteers')).toBeInTheDocument()
+  })
+
+  it('renders the title inside an <h1>', () => {
+    render(<ResultCard title="50" description="Partners" />)
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('50')
+  })
+
+  it('falls back to plain text for titles that mix digits and letters', () => {
+    render(<ResultCard title="100+" description="Hours" />)
+    expect(screen.getByText('100+')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/ui/TeamMemberCard.test.tsx
+++ b/__tests__/components/ui/TeamMemberCard.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import TeamMemberCard from '../../../src/components/ui/TeamMemberCard'
+
+describe('TeamMemberCard', () => {
+  const baseProps = {
+    imageUrl: '/Images/member1.webp',
+    name: 'Jane Doe',
+    title: 'Executive Director',
+    linkedinUrl: 'https://www.linkedin.com/in/janedoe',
+  }
+
+  it('renders the team member name and title', () => {
+    render(<TeamMemberCard {...baseProps} />)
+    expect(screen.getByRole('heading', { level: 3, name: 'Jane Doe' })).toBeInTheDocument()
+    expect(screen.getByText('Executive Director')).toBeInTheDocument()
+  })
+
+  it('uses the name as the alt text on the portrait image', () => {
+    render(<TeamMemberCard {...baseProps} />)
+    expect(screen.getByAltText('Jane Doe')).toBeInTheDocument()
+  })
+
+  it('wires the LinkedIn link to the provided URL with safe rel attributes', () => {
+    render(<TeamMemberCard {...baseProps} />)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', baseProps.linkedinUrl)
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('renders the linkedin icon image with alt text', () => {
+    render(<TeamMemberCard {...baseProps} />)
+    expect(screen.getByAltText('linkedin icon')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Closes the coverage gap for the five highest-reuse UI components. Before this PR, 25 of 28 components in `src/components/ui/` had zero Jest coverage; only Header, Footer, and CookieConsent had tests.

## What's covered

| Component | Cases | What's asserted |
| --- | ---: | --- |
| `BlogCard.tsx` | 5 | heading + description rendering, optional date, link wiring with safe `rel` attrs, conditional image presence |
| `AnimatedNumber.tsx` | 4 | value display, `className`/`id` prop wiring, zero handling |
| `TeamMemberCard.tsx` | 4 | name + title rendering, portrait alt text, LinkedIn link wiring with safe `rel` attrs, linkedin icon |
| `ResultCard.tsx` | 4 | numeric vs non-numeric title routing through `AnimatedNumber`, `<h1>` wrapping, mixed-content (`100+`) fallback |
| `ApplicationFormButton.tsx` | 6 | default vs custom label, modal open/close lifecycle, iframe URL wiring with default and custom `formUrl` |

**Jest test count: 41 → 64 (+23).**

## A note on framer-motion mocking

`AnimatedNumber` (and `ResultCard` indirectly) use `useInView` from `framer-motion`, which is backed by `IntersectionObserver`. jsdom does not provide `IntersectionObserver`, so the tests for these two files install a tiny `jest.mock('framer-motion', ...)` that:

- returns `useReducedMotion=true` so the static render path is exercised
- returns `useInView=true` so the in-view branch is taken
- provides minimal `useMotionValue`/`useSpring` shims
- proxies any `motion.<tag>` access to a passthrough `<span>`

The other three components don't touch framer-motion and don't need the mock.

## Verification

- `npm test -- __tests__/components/ui/` — 23/23 passed
- `npm test` — 64/64 passed (10 suites)
- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings
- `npm run build` — 13 pages exported
- `npm run test:e2e` — 65 passed, 1 skipped, 5 pre-existing env failures (GTM + iframe — unrelated)
- `npm run check:drift` — green
- Husky pre-commit hooks — green
- Jest coverage report now includes all five components

## Coordination

- Pairs with **#278** (threshold raise to 20%) — that lands AFTER this PR and #277. Test count change is intentionally large for that purpose.

## Test plan

- [x] 5 new `*.test.tsx` files under `__tests__/components/ui/`
- [x] All assert visible text and primary prop wiring
- [x] `npm test` green
- [x] Jest coverage report covers the 5 components

Fixes #276
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_