### PR TITLE
test: add unit tests for 10 untested home-page sections

### DIFF
--- a/__tests__/components/home-page/Endowment-Features.test.tsx
+++ b/__tests__/components/home-page/Endowment-Features.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import EndowmentFeatures from '../../../src/components/home-page/Endowment-Features'
+
+describe('Endowment-Features', () => {
+  it('renders the section heading', () => {
+    render(<EndowmentFeatures />)
+    expect(
+      screen.getByRole('heading', { name: /Free For Charity Endowment Features/i })
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/home-page/FrequentlyAskedQuestions.test.tsx
+++ b/__tests__/components/home-page/FrequentlyAskedQuestions.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import FAQ from '../../../src/components/home-page/FrequentlyAskedQuestions'
+
+describe('FrequentlyAskedQuestions', () => {
+  it('renders the section heading', () => {
+    render(<FAQ />)
+    expect(screen.getByRole('heading', { name: /Frequently Asked Questions/i })).toBeInTheDocument()
+  })
+
+  it('mounts under the #faq section landmark id', () => {
+    const { container } = render(<FAQ />)
+    expect(container.querySelector('#faq')).not.toBeNull()
+  })
+})

--- a/__tests__/components/home-page/Hero.test.tsx
+++ b/__tests__/components/home-page/Hero.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Hero from '../../../src/components/home-page/Hero'
+
+describe('Hero', () => {
+  it('renders the welcome headline', () => {
+    render(<Hero />)
+    // The heading mixes text with a <br/>, so the rendered DOM is two text
+    // nodes inside the same <h1>. Match the whole heading by accessible name
+    // and let RTL collapse whitespace.
+    expect(
+      screen.getByRole('heading', { level: 1, name: /Welcome to\s+Free For Charity/i })
+    ).toBeInTheDocument()
+  })
+
+  it('mounts under the #hero section landmark id', () => {
+    const { container } = render(<Hero />)
+    expect(container.querySelector('#hero')).not.toBeNull()
+  })
+})

--- a/__tests__/components/home-page/Mission.test.tsx
+++ b/__tests__/components/home-page/Mission.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Mission from '../../../src/components/home-page/Mission'
+
+describe('Mission', () => {
+  it('renders the section heading', () => {
+    render(<Mission />)
+    expect(
+      screen.getByRole('heading', {
+        name: /Free For Charity has a simple mission with broad implications/i,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('mounts under the #mission section landmark id', () => {
+    const { container } = render(<Mission />)
+    expect(container.querySelector('#mission')).not.toBeNull()
+  })
+
+  it('renders the embedded mission video element', () => {
+    const { container } = render(<Mission />)
+    expect(container.querySelector('video')).not.toBeNull()
+  })
+})

--- a/__tests__/components/home-page/Our-Programs.test.tsx
+++ b/__tests__/components/home-page/Our-Programs.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import OurPrograms from '../../../src/components/home-page/Our-Programs'
+
+describe('Our-Programs', () => {
+  it('renders the section heading', () => {
+    render(<OurPrograms />)
+    expect(screen.getByRole('heading', { name: /Our Programs/i })).toBeInTheDocument()
+  })
+
+  it('mounts under the #programs section landmark id', () => {
+    const { container } = render(<OurPrograms />)
+    expect(container.querySelector('#programs')).not.toBeNull()
+  })
+})

--- a/__tests__/components/home-page/Results-2023.test.tsx
+++ b/__tests__/components/home-page/Results-2023.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+// Results-2023 renders four ResultCards, each of which uses framer-motion's
+// IntersectionObserver-backed useInView via AnimatedNumber. Mock framer-motion
+// so the static render path is taken (same shape as the AnimatedNumber and
+// ResultCard suite mocks).
+jest.mock('framer-motion', () => {
+  return {
+    useReducedMotion: () => true,
+    useInView: () => true,
+    useMotionValue: (initial: number) => ({
+      set: jest.fn(),
+      get: () => initial,
+      on: () => () => undefined,
+    }),
+    useSpring: (mv: { on: (event: string, cb: (latest: number) => void) => () => void }) => mv,
+    motion: new Proxy(
+      {},
+      {
+        get: () => {
+          const Pass = ({ children, ...rest }: React.PropsWithChildren<Record<string, unknown>>) =>
+            React.createElement('span', rest, children)
+          return Pass
+        },
+      }
+    ),
+  }
+})
+
+import Results from '../../../src/components/home-page/Results-2023'
+
+describe('Results-2023', () => {
+  it('renders the section heading', () => {
+    render(<Results />)
+    expect(screen.getByRole('heading', { level: 1, name: /Results - 2023/i })).toBeInTheDocument()
+  })
+
+  it('mounts under the #results section landmark id', () => {
+    const { container } = render(<Results />)
+    expect(container.querySelector('#results')).not.toBeNull()
+  })
+
+  it('renders four stat cards', () => {
+    const { container } = render(<Results />)
+    // Each ResultCard wraps a value in <h1>; the section heading is also <h1>,
+    // so the count is 1 (heading) + 4 (cards) = 5.
+    const headings = container.querySelectorAll('h1')
+    expect(headings.length).toBe(5)
+  })
+})

--- a/__tests__/components/home-page/SupportFreeForCharity.test.tsx
+++ b/__tests__/components/home-page/SupportFreeForCharity.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Support from '../../../src/components/home-page/SupportFreeForCharity'
+
+describe('SupportFreeForCharity', () => {
+  it('renders the section heading', () => {
+    render(<Support />)
+    expect(screen.getByRole('heading', { name: /Support Free For Charity/i })).toBeInTheDocument()
+  })
+
+  it('mounts under the #donate section landmark id', () => {
+    const { container } = render(<Support />)
+    expect(container.querySelector('#donate')).not.toBeNull()
+  })
+})

--- a/__tests__/components/home-page/TheFreeForCharityTeam.test.tsx
+++ b/__tests__/components/home-page/TheFreeForCharityTeam.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Team from '../../../src/components/home-page/TheFreeForCharityTeam'
+
+describe('TheFreeForCharityTeam', () => {
+  it('renders the section heading', () => {
+    render(<Team />)
+    expect(screen.getByRole('heading', { name: /The Free For Charity Team/i })).toBeInTheDocument()
+  })
+
+  it('mounts under the #team section landmark id', () => {
+    const { container } = render(<Team />)
+    expect(container.querySelector('#team')).not.toBeNull()
+  })
+})

--- a/__tests__/components/home-page/VoicesofGratitude.test.tsx
+++ b/__tests__/components/home-page/VoicesofGratitude.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import VoicesofGratitude from '../../../src/components/home-page/VoicesofGratitude'
+
+describe('VoicesofGratitude', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+    jest.useRealTimers()
+  })
+
+  it('renders the section heading', () => {
+    render(<VoicesofGratitude />)
+    expect(screen.getByRole('heading', { name: /Voices of Gratitude/i })).toBeInTheDocument()
+  })
+
+  it('renders at least one testimonial quote on initial mount', () => {
+    render(<VoicesofGratitude />)
+    // Each testimonial text starts with a typographic open-quote character.
+    expect(screen.getAllByText(/“/i).length).toBeGreaterThan(0)
+  })
+})

--- a/__tests__/components/home-page/Volunteer-with-Us.test.tsx
+++ b/__tests__/components/home-page/Volunteer-with-Us.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Volunteer from '../../../src/components/home-page/Volunteer-with-Us'
+
+describe('Volunteer-with-Us', () => {
+  it('renders the section heading', () => {
+    render(<Volunteer />)
+    expect(screen.getByRole('heading', { name: /Volunteer with Us/i })).toBeInTheDocument()
+  })
+
+  it('mounts under the #volunteer section landmark id', () => {
+    const { container } = render(<Volunteer />)
+    expect(container.querySelector('#volunteer')).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Adds the 10 missing home-page section tests. Before this PR, 10 of 12 home-page sections had zero Jest coverage. The Events section is excluded per the issue (its tests live in #270 alongside the #268 rewrite).

## What's covered

| Section | Cases | What's asserted |
| --- | ---: | --- |
| `Hero` | 2 | welcome headline (`<h1>`), `#hero` landmark |
| `Mission` | 3 | section heading, `#mission` landmark, embedded `<video>` |
| `Volunteer-with-Us` | 2 | section heading, `#volunteer` landmark |
| `Our-Programs` | 2 | section heading, `#programs` landmark |
| `Results-2023` | 3 | section heading, `#results` landmark, 4 stat cards |
| `Endowment-Features` | 1 | section heading |
| `TheFreeForCharityTeam` | 2 | section heading, `#team` landmark |
| `VoicesofGratitude` | 2 | section heading, testimonial quotes present |
| `SupportFreeForCharity` | 2 | section heading, `#donate` landmark |
| `FrequentlyAskedQuestions` | 2 | section heading, `#faq` landmark |

**Jest test count: 41 → 62 (+21).**

## Notes on determinism

- `Results-2023` mocks `framer-motion` the same way the UI `ResultCard`/`AnimatedNumber` tests do (#276) — `ResultCard` uses `AnimatedNumber` for numeric titles, and that depends on `IntersectionObserver` which jsdom doesn't provide.
- `VoicesofGratitude` uses `jest.useFakeTimers()` to keep its `setInterval` auto-scroll from leaking timers across tests.
- No network, no real timers.

## Coordination

- **#268 (Events redesign)** — explicitly skipped the Events section here per the issue's coordination note. The new tests for Events ship in #270.
- **#278 (threshold raise to 20%)** — lands after this PR and #276; together they push real coverage well above 20%.

## Verification

- `npm test -- __tests__/components/home-page/` — 21/21 passed
- `npm test` — 62/62 passed (15 suites)
- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings
- `npm run build` — 13 pages exported
- `npm run test:e2e` — 65 passed, 1 skipped, 5 pre-existing env failures (unrelated)
- `npm run check:drift` — green
- Husky pre-commit hooks — green

## Test plan

- [x] 10 new test files under `__tests__/components/home-page/`
- [x] Suite is green; no regressions
- [x] Each test is deterministic (no network; the one component using `setInterval` is gated by `jest.useFakeTimers`)
- [x] No test added for `Events` (deferred to #270 per #277's coordination note)

Fixes #277
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_