### PR TITLE
perf: lazy-load below-the-fold homepage images

### DIFF
--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -19,7 +19,12 @@ const index = () => {
           <div className="mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src={assetPath('/Svgs/FFC-Domains.svg')} alt="FFC-Domains" fill></Image>
+                <Image
+                  src={assetPath('/Svgs/FFC-Domains.svg')}
+                  alt="FFC-Domains"
+                  fill
+                  loading="lazy"
+                ></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400] " id="lato-font">
@@ -75,7 +80,12 @@ const index = () => {
           <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src={assetPath('/Svgs/FFC-Hosting.svg')} alt="FFC-Domains" fill></Image>
+                <Image
+                  src={assetPath('/Svgs/FFC-Hosting.svg')}
+                  alt="FFC-Domains"
+                  fill
+                  loading="lazy"
+                ></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400]  " id="lato-font">
@@ -141,7 +151,12 @@ const index = () => {
           <div className="lg:pl-[50px] mb-[40px]  flex items-center gap-[20px]">
             <div className="w-[100px] flex items-center justify-center p-2 h-[100px] bg-[#2A6682] rounded-full">
               <div className="relative w-[56px] h-[56px]">
-                <Image src={assetPath('/Svgs/FFC-Consulting.svg')} alt="FFC-Domains" fill></Image>
+                <Image
+                  src={assetPath('/Svgs/FFC-Consulting.svg')}
+                  alt="FFC-Domains"
+                  fill
+                  loading="lazy"
+                ></Image>
               </div>
             </div>
             <h1 className="text-[36px] font-[400]  " id="lato-font">

--- a/src/components/home-page/VoicesofGratitude/index.tsx
+++ b/src/components/home-page/VoicesofGratitude/index.tsx
@@ -83,6 +83,7 @@ export default function TestimonialSlider() {
                               height={29}
                               alt="start icon"
                               className="mx-[5px]"
+                              loading="lazy"
                             ></Image>
                           ))}
                         </div>

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -28,7 +28,7 @@ export default function TeamMemberCard({
             fill
             className="object-cover"
             sizes="(max-width: 768px) 100vw, 192px"
-            priority
+            loading="lazy"
           />
         </div>
 
@@ -49,6 +49,7 @@ export default function TeamMemberCard({
             width={63}
             height={63}
             alt="linkedin icon"
+            loading="lazy"
           ></Image>
         </a>
       </div>


### PR DESCRIPTION
## Summary

Adds `loading="lazy"` to every below-the-fold `<Image>` on the homepage. The Hero image is correctly `priority`; `Volunteer-with-Us` and `SupportFreeForCharity` already had `loading="lazy"`. This PR closes the gaps in the remaining home-page sections and corrects a misuse of `priority` on the team-member portrait.

## Changes

| File | Before | After |
| --- | --- | --- |
| `src/components/home-page/Our-Programs/index.tsx` (3 program-icon Images) | no attr | `loading="lazy"` |
| `src/components/home-page/VoicesofGratitude/index.tsx` (star icons) | no attr | `loading="lazy"` |
| `src/components/ui/TeamMemberCard.tsx` (portrait) | **`priority`** | `loading="lazy"` |
| `src/components/ui/TeamMemberCard.tsx` (LinkedIn icon) | no attr | `loading="lazy"` |

`TeamMemberCard` is only used inside `home-page/TheFreeForCharityTeam`, which is rendered far below the fold; the `priority` flag was net negative there (it preloaded several portrait images while the visitor was still looking at the hero).

## Coordination

- **`src/components/home-page/Events/` intentionally skipped** per the issue's coordination note — that component is being rewritten under #268, and the lazy-load decision belongs to that work. PR #268 isn't open yet; if it lands before this PR a follow-up will lazy-load the new event cards.

## Verification

- `grep -rn "<Image\\|<img" src/components/home-page/` (excluding Events) — every Image now has `priority` (Hero only) or `loading="lazy"`
- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings
- `npm test` — 41/41 passed (existing tests around the touched images still green)
- `npm run build` — 13 pages exported
- `npm run test:e2e` — 65 passed, 1 skipped, 5 pre-existing env failures (unrelated)
- `npm run check:drift` — green
- Husky pre-commit hooks — green

A Lighthouse run on the homepage is recommended after deploy to confirm no LCP regression — should be neutral or improved since the team portraits no longer compete with the hero for early bandwidth.

## Test plan

- [x] Every below-fold image has `loading="lazy"`
- [x] Above-fold image (Hero) retains `priority`
- [x] `npm run build` green
- [ ] Lighthouse run on the deployed site after merge confirms no regression (post-deploy check)

Fixes #282
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_