### PR TITLE
feat(a11y): respect prefers-reduced-motion across animated UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,3 +160,19 @@ body {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+/* WCAG 2.3.3 — respect the user's reduced-motion preference. Collapses
+   CSS transitions and animations to near-instant. JS-driven animations
+   (e.g., framer-motion in AnimatedNumber, the setInterval auto-scroll in
+   VoicesofGratitude) read prefers-reduced-motion separately in their own
+   components and snap to the end state when it is set. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/components/home-page/VoicesofGratitude/index.tsx
+++ b/src/components/home-page/VoicesofGratitude/index.tsx
@@ -2,9 +2,11 @@
 
 import React, { useState, useEffect } from 'react'
 import Image from 'next/image'
+import { useReducedMotion } from 'framer-motion'
 import { assetPath } from '@/lib/assetPath'
 
 export default function TestimonialSlider() {
+  const prefersReducedMotion = useReducedMotion()
   const testimonials = [
     {
       name: 'Name',
@@ -26,16 +28,18 @@ export default function TestimonialSlider() {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isPaused, setIsPaused] = useState(false)
 
-  // Auto-scroll behavior
+  // Auto-scroll behavior. Disabled entirely when the user prefers reduced
+  // motion (WCAG 2.3.3) — slides only change when they tap a pagination
+  // dot. Also disabled while a pointer hovers the slider (existing behavior).
   useEffect(() => {
-    if (isPaused) return
+    if (isPaused || prefersReducedMotion) return
 
     const interval = setInterval(() => {
       setCurrentIndex((prev) => (prev + 1) % testimonials.length)
     }, 4000) // Change slide every 4 seconds
 
     return () => clearInterval(interval)
-  }, [isPaused, testimonials.length])
+  }, [isPaused, prefersReducedMotion, testimonials.length])
 
   const goToSlide = (index: number) => {
     setCurrentIndex(index)

--- a/tests/reduced-motion.spec.ts
+++ b/tests/reduced-motion.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * WCAG 2.3.3 guardrail: when the user has prefers-reduced-motion: reduce,
+ * animated UI must not subject them to motion. The Results section's
+ * AnimatedNumber is the canonical case — under reduced motion it should
+ * render its final value immediately rather than counting up.
+ *
+ * NOTE: this spec calls `page.emulateMedia` explicitly *before* navigating
+ * rather than relying on the `reducedMotion` test-fixture option. The
+ * fixture is applied per-context but framer-motion's `useReducedMotion`
+ * subscribes to the live media-query at mount time, so we set it before
+ * the first paint so the component's `prefersReducedMotion` value is
+ * `true` from the very first render.
+ */
+
+test.describe('prefers-reduced-motion', () => {
+  test('Results-2023 stat numbers settle without a multi-frame animation', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.goto('/')
+
+    // Scroll Results-2023 into view so AnimatedNumber's useInView fires.
+    await page.locator('#results').scrollIntoViewIfNeeded()
+
+    // Find the four stat-card headings (the first <h1> under #results is
+    // the section title "Results - 2023"; the four numeric ones come next).
+    const statHeadings = page.locator('#results h1').filter({ hasText: /^\d/ })
+    await expect(statHeadings).toHaveCount(4)
+
+    // Poll until two consecutive reads match. Under reduced-motion the
+    // component renders its final value as a plain <span> as soon as the
+    // useReducedMotion effect commits — so a stable read should arrive
+    // within a few hundred milliseconds. Under a full spring (the regular
+    // motion path) the value would change on every frame for ~1s and this
+    // loop would never converge inside the allotted window.
+    const settled = await page.evaluate(async () => {
+      const reads = (): string[] =>
+        Array.from(document.querySelectorAll('#results h1'))
+          .map((el) => (el.textContent ?? '').trim())
+          .filter((t) => /^\d+$/.test(t))
+
+      const deadline = Date.now() + 1500
+      let prev = reads()
+      while (Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 75))
+        const curr = reads()
+        if (curr.length === 4 && curr.every((v, i) => v === prev[i])) {
+          return curr
+        }
+        prev = curr
+      }
+      return null
+    })
+
+    expect(settled).not.toBeNull()
+    expect(settled).toHaveLength(4)
+    for (const v of settled as string[]) {
+      expect(v).toMatch(/^\d+$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

WCAG 2.3.3 baseline. `AnimatedNumber` already handled reduced motion via framer-motion's `useReducedMotion` hook; this PR closes two remaining gaps and adds a regression guardrail.

## Changes

### 1. `src/app/globals.css` — global reduced-motion override

Adds a single `@media (prefers-reduced-motion: reduce)` block that collapses `animation-duration`, `animation-iteration-count`, `transition-duration` to `0.01ms` for all elements, plus disables `scroll-behavior`. Covers:

- Every Tailwind `transition-*` utility used across the site (BlogCard hover, header menu, cookie banner, etc.)
- The repo's own `.animate-fadeLeft` / `.animate-fadeRight` keyframe utilities
- Any CSS animation introduced in the future

### 2. `src/components/home-page/VoicesofGratitude/index.tsx` — pause auto-scroll

The testimonial slider auto-advanced every 4 seconds via `setInterval` regardless of user preference. Now reads `useReducedMotion` and short-circuits the interval when `reduce` is set. Visitors still navigate via the pagination dots.

### 3. `tests/reduced-motion.spec.ts` — Playwright guardrail

New spec asserts that with `prefers-reduced-motion: reduce` active, the Results-2023 stat numbers settle to integer final values without a multi-frame spring animation. Implementation note in the spec: `page.emulateMedia({ reducedMotion: 'reduce' })` is called **before** `page.goto('/')` so the media query is correct from the very first paint — the test-fixture `reducedMotion` option is set per-context but framer-motion's `useReducedMotion` subscribes at mount time, so the explicit-emulate pattern is more reliable.

## Audit coverage

- `AnimatedNumber.tsx` — already correct (verified)
- `VoicesofGratitude` (auto-scroll) — fixed in this PR
- BlogCard, Accordion, Header, CookieConsent, etc. (CSS transitions) — covered by the new global CSS rule
- `.animate-fadeLeft` / `.animate-fadeRight` keyframe utilities in `globals.css` — covered by the new rule

## Verification

- New spec `tests/reduced-motion.spec.ts` — passes
- `npm run format` — clean
- `npm run lint` — 0 errors, 7 pre-existing warnings
- `npm test` — 41/41 passed
- `npm run build` — 13 pages exported
- `npm run test:e2e` — 66 passed (incl. new reduced-motion spec), 1 skipped, 5 pre-existing env failures (unrelated)
- `npm run check:drift` — green
- Husky pre-commit hooks — green
- No new console warnings

## Test plan

- [x] Playwright spec with `emulateMedia({ reducedMotion: 'reduce' })` confirms `AnimatedNumber` displays a stable final value without animation
- [x] Default (no reduced-motion preference) behavior is unchanged
- [x] No new console warnings

Fixes #297
Refs #298

---
_Generated by [Claude Code](https://claude.ai/code/session_019GxcMXuRgXaRd4vBMSGSTP)_