### PR TITLE
fix(deploy): auto-select NEXT_PUBLIC_BASE_PATH from CNAME (fixes 404 PWA icons on custom domains)

### DIFF
--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -24,8 +24,7 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
    - `Canonical:` / `Policy:` / `Acknowledgments:` use the new URL
    - `Expires:` is at least 12 months out, formatted `YYYY-MM-DDTHH:MM:SSZ`
 
-5. **Update `.github/workflows/deploy.yml` and `.github/workflows/lighthouse.yml`**:
-   - Change `NEXT_PUBLIC_BASE_PATH` from `/FFC_Single_Page_Template` to `/your-repo-name` if you renamed the repo for a github.io subpath fallback. If using a custom domain only, you can leave the value as-is (the CNAME takes precedence at the host level).
+5. **Deploy workflows** — no edits required. `deploy.yml` and `lighthouse.yml` choose `NEXT_PUBLIC_BASE_PATH` automatically: empty if `public/CNAME` exists (custom-domain root deploy), otherwise `/<repo-name>` (github.io subpath fallback). Just commit the CNAME or skip it as appropriate in step 3.
 
 6. **Swap branded assets** in `public/Images/` and `public/Svgs/`. Keep filenames where possible so the LCP preload in `layout.tsx` and the manifest icons still hit real files.
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,12 +61,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Determine base path
+        id: basepath
+        # Custom-domain deploys serve from the origin root (no subpath), so
+        # NEXT_PUBLIC_BASE_PATH must be empty. Subpath-only deploys (no
+        # CNAME) need /<repo-name>. Empirically the live site at
+        # ffcworkingsite1.org/manifest.webmanifest referenced
+        # /FFC_Single_Page_Template/android-chrome-*.png because the build
+        # always set the subpath, but those paths 404 on the custom domain.
+        # This step picks the right value based on whether public/CNAME
+        # exists.
+        run: |
+          if [ -s "public/CNAME" ]; then
+            echo "Using empty basePath (public/CNAME present: $(cat public/CNAME))"
+            echo "value=" >> "$GITHUB_OUTPUT"
+          else
+            REPO_NAME="${GITHUB_REPOSITORY#*/}"
+            echo "Using /$REPO_NAME basePath (no CNAME — github.io subpath deploy)"
+            echo "value=/$REPO_NAME" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build with Next.js
         run: npm run build
         env:
-          # Set basePath for GitHub Pages deployment
-          # This ensures images and assets work correctly at the subpath
-          NEXT_PUBLIC_BASE_PATH: /FFC_Single_Page_Template
+          # See "Determine base path" above. Set automatically based on
+          # whether public/CNAME exists.
+          NEXT_PUBLIC_BASE_PATH: ${{ steps.basepath.outputs.value }}
 
       - name: Upload artifact for Pages
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -39,10 +39,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Determine base path
+        id: basepath
+        # Match deploy.yml: custom-domain deploys (public/CNAME present)
+        # serve from root with empty basePath; subpath-only deploys use
+        # /<repo-name>. Lighthouse must audit the same URL structure the
+        # production deploy uses or it'll measure 404 pages.
+        run: |
+          if [ -s "public/CNAME" ]; then
+            echo "value=" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=/${GITHUB_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build site
         run: npm run build
         env:
-          NEXT_PUBLIC_BASE_PATH: /FFC_Single_Page_Template
+          NEXT_PUBLIC_BASE_PATH: ${{ steps.basepath.outputs.value }}
 
       - name: Run Lighthouse CI
         run: |

--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ hand or use the same address for both.
    - REVIEW with the charity's counsel before committing. Update org name
      references.
 
-9. .github/workflows/deploy.yml
-   - If using a github.io subpath fallback, update NEXT_PUBLIC_BASE_PATH to
-     the new repository name. If using a custom domain only, you can leave
-     this as-is (the CNAME takes precedence).
+9. .github/workflows/deploy.yml, .github/workflows/lighthouse.yml
+   - NO edits required. `NEXT_PUBLIC_BASE_PATH` is now chosen automatically
+     based on whether `public/CNAME` is present (empty if CNAME exists,
+     `/<repo-name>` if not). Renaming the repo doesn't require a workflow
+     edit.
 
 10. README.md, GitHub repo description, CITATION.cff
     - Update organization name, repo links, and citation metadata.

--- a/TEMPLATE_CUSTOMIZATION.md
+++ b/TEMPLATE_CUSTOMIZATION.md
@@ -32,7 +32,7 @@ charity's name, URL, contact email, social links, etc.
 
 - **EIN, mailing addresses, phone numbers** — still hardcoded in `src/components/footer/index.tsx`. Add to siteConfig if your charity wants them.
 - **Hero/section copy** — lives in component files under `src/components/home-page/` and `src/data/`.
-- **GitHub Pages base path** — read directly from `NEXT_PUBLIC_BASE_PATH` in `.github/workflows/deploy.yml` and `.github/workflows/lighthouse.yml`. Update the workflow value when you rename the repo.
+- **GitHub Pages base path** — chosen automatically by `deploy.yml` and `lighthouse.yml` based on whether `public/CNAME` exists. With a CNAME the build uses an empty basePath (custom-domain root). Without a CNAME the build uses `/<repo-name>` for github.io subpath deploys. No manual workflow edit required when you rename the repo.
 - **OG/Twitter card image** — `layout.tsx` points at `/web-app-manifest-512x512.png` (square 512×512). For a proper social-card preview, replace the file with a 1200×630 image keeping the same filename, or update both layout.tsx references to point at a new asset.
 
 After editing, **run `npm run check:drift`** to confirm nothing else still
@@ -40,16 +40,15 @@ references the old placeholder values.
 
 ## Files you'll likely touch when rebranding
 
-| File                                                               | What to change                                                                                                                                                                                                        |
-| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `public/CNAME`                                                     | Custom domain (delete if using only github.io)                                                                                                                                                                        |
-| `public/.well-known/security.txt` **and** `public/security.txt`    | `Contact`, `Canonical`, `Policy`, `Acknowledgments`, `Expires`. **Both copies must stay in sync** (the drift checker enforces it). The root copy exists because GitHub Pages does not serve dot-prefixed directories. |
-| `public/Images/*`, `public/Svgs/*`                                 | Brand assets (keep filenames where possible)                                                                                                                                                                          |
-| `src/components/footer/index.tsx`                                  | EIN, addresses, phone, GuideStar profile URLs, parent-org footer link — these are not in `siteConfig` (yet)                                                                                                           |
-| `src/data/*`                                                       | Testimonials, FAQs, team — your real content                                                                                                                                                                          |
-| `src/components/home-page/*`                                       | Home page sections                                                                                                                                                                                                    |
-| `src/app/privacy-policy/page.tsx` etc                              | Legal pages (have a lawyer review)                                                                                                                                                                                    |
-| `.github/workflows/deploy.yml`, `.github/workflows/lighthouse.yml` | `NEXT_PUBLIC_BASE_PATH` — set to `/your-repo-name` for github.io subpath deploys (or leave default if using a custom domain only)                                                                                     |
+| File                                                            | What to change                                                                                                                                                                                                        |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `public/CNAME`                                                  | Custom domain (delete if using only github.io)                                                                                                                                                                        |
+| `public/.well-known/security.txt` **and** `public/security.txt` | `Contact`, `Canonical`, `Policy`, `Acknowledgments`, `Expires`. **Both copies must stay in sync** (the drift checker enforces it). The root copy exists because GitHub Pages does not serve dot-prefixed directories. |
+| `public/Images/*`, `public/Svgs/*`                              | Brand assets (keep filenames where possible)                                                                                                                                                                          |
+| `src/components/footer/index.tsx`                               | EIN, addresses, phone, GuideStar profile URLs, parent-org footer link — these are not in `siteConfig` (yet)                                                                                                           |
+| `src/data/*`                                                    | Testimonials, FAQs, team — your real content                                                                                                                                                                          |
+| `src/components/home-page/*`                                    | Home page sections                                                                                                                                                                                                    |
+| `src/app/privacy-policy/page.tsx` etc                           | Legal pages (have a lawyer review)                                                                                                                                                                                    |
 
 The web manifest is **auto-generated** from `siteConfig` at build time by `src/app/manifest.ts` — no separate file to edit.
 

--- a/TEMPLATE_SETUP_CHECKLIST.md
+++ b/TEMPLATE_SETUP_CHECKLIST.md
@@ -35,9 +35,10 @@ Quick reference checklist for setting up a new repository from the FFC Single Pa
 - [ ] Custom domain (if applicable): Enter domain name and click "Save"
 - [ ] Wait for DNS check to complete
 - [ ] Enable "Enforce HTTPS" (after DNS configured)
-- [ ] If using a github.io subpath fallback, also update
-      `NEXT_PUBLIC_BASE_PATH` in `.github/workflows/deploy.yml` and
-      `.github/workflows/lighthouse.yml` to `/your-repo-name`
+- [ ] `NEXT_PUBLIC_BASE_PATH` is now selected automatically by
+      `deploy.yml` and `lighthouse.yml` from `public/CNAME` (empty when
+      CNAME is present, `/<repo-name>` when it's not). No manual edit
+      required.
 
 ### Actions Permissions (Settings → Actions → General)
 
@@ -76,13 +77,17 @@ Create ruleset named "Protect Main":
 
 ## Update Repository Configuration Files
 
-### Update basePath in Workflows
+### basePath in Workflows — automatic
 
-- [ ] Edit `.github/workflows/deploy.yml`
-  - In the job that builds the Next.js site (look for the `env` section where `NEXT_PUBLIC_BASE_PATH` is set), change `/FFC_Single_Page_Template` to `/YOUR-REPO-NAME`
-- [ ] Edit `.github/workflows/lighthouse.yml`
-  - In the job that runs the Lighthouse checks (look for the `env` section where `NEXT_PUBLIC_BASE_PATH` is set), change `/FFC_Single_Page_Template` to `/YOUR-REPO-NAME`
-- [ ] OR remove `NEXT_PUBLIC_BASE_PATH` if using custom domain
+`deploy.yml` and `lighthouse.yml` derive `NEXT_PUBLIC_BASE_PATH` from
+`public/CNAME` at build time:
+
+- **Custom domain** (CNAME file present): build uses empty basePath so
+  asset URLs resolve from the origin root.
+- **github.io subpath** (no CNAME): build uses `/<repo-name>` so asset
+  URLs resolve under the Pages subpath.
+
+You don't have to edit either workflow when you rename the repo.
 
 ### Update CODEOWNERS
 
@@ -269,15 +274,20 @@ Create ruleset named "Protect Main":
 1. Verify Pages source is set to **"GitHub Actions"** (Settings → Pages → Source)
 2. Wait 2-5 minutes for propagation
 3. Check Actions tab for the "Deploy to GitHub Pages" workflow status
-4. Verify `NEXT_PUBLIC_BASE_PATH` in `.github/workflows/deploy.yml` matches the repo name (e.g. `/my-charity-site`)
-5. If you have a custom domain, confirm `public/CNAME` contains it (no scheme, no trailing slash)
+4. Confirm the "Determine base path" step in the deploy run printed the
+   expected value (empty for custom-domain deploys, `/<repo-name>` for
+   subpath deploys)
+5. If you have a custom domain, confirm `public/CNAME` contains it
+   (no scheme, no trailing slash)
 
 ### Images don't load on GitHub Pages
 
 ✅ **Solution**:
 
-1. Verify `NEXT_PUBLIC_BASE_PATH` is correct in deploy.yml
-2. Check images use `assetPath()` helper
+1. Check the deploy run's "Determine base path" step printed the
+   expected value for your setup (empty with CNAME, `/<repo-name>` without)
+2. Confirm all image references use the `assetPath()` helper — `npm run
+check:drift` will fail if any are missing
 3. Rebuild and redeploy
 
 ### Commits rejected (unsigned)


### PR DESCRIPTION
## Summary

Smoke-check expansion in #304 surfaced a real production bug: the live `/manifest.webmanifest` on the custom domain references PWA icon paths under `/FFC_Single_Page_Template/...`, but the site actually serves from `ffcworkingsite1.org/` (root). Those icon paths 404 in production, so the installed-PWA icon falls back to the default browser icon on every charity site using a custom domain.

```
$ curl -s https://ffcworkingsite1.org/manifest.webmanifest
{"icons":[{"src":"/FFC_Single_Page_Template/android-chrome-192x192.png", ...}]}
$ curl -sI https://ffcworkingsite1.org/FFC_Single_Page_Template/android-chrome-192x192.png
HTTP/2 404
$ curl -sI https://ffcworkingsite1.org/android-chrome-192x192.png
HTTP/2 200
```

Root cause: `deploy.yml` and `lighthouse.yml` both hardcoded `NEXT_PUBLIC_BASE_PATH=/FFC_Single_Page_Template` regardless of where the site actually deploys. A charity renaming the repo had to remember to edit two workflow files; a charity deploying behind a custom domain had to remember to clear the value. Empirically that didn't happen on this template's own deployment.

## Fix

New "Determine base path" step in both workflows reads `public/CNAME` at build time and sets the env var:

- **CNAME present** → empty basePath (custom-domain root deploy; asset URLs resolve from `/`)
- **CNAME absent** → `/<repo-name>` (github.io subpath deploy; asset URLs resolve from `/<repo>/`)

## Verified locally

```
$ NEXT_PUBLIC_BASE_PATH="" npm run build && head out/manifest.webmanifest
{"icons":[{"src":"/android-chrome-192x192.png", ...}]}

$ NEXT_PUBLIC_BASE_PATH=/my-repo npm run build && head out/manifest.webmanifest
{"icons":[{"src":"/my-repo/android-chrome-192x192.png", ...}]}
```

## Docs swept to match

- `TEMPLATE_CUSTOMIZATION.md`: "Things siteConfig does NOT yet drive" no longer says "Update the workflow value when you rename the repo"; clarifies the auto-selection
- `TEMPLATE_SETUP_CHECKLIST.md`: rewrote the "Update basePath in Workflows" section; updated the GH Pages 404 troubleshooting to point at the new step's log output
- `.claude/agents/onboarding.md`: step 5 no longer instructs the agent to edit `NEXT_PUBLIC_BASE_PATH`
- `README.md` customization prompt: step 9 changed to "NO edits required" with an explanation

## Test plan

- [x] `npm run format` clean
- [x] `npm run lint` 0 errors
- [x] `npm run check:drift` 0 errors
- [x] `npm test` 41/41
- [x] Build with `NEXT_PUBLIC_BASE_PATH=""` → manifest icons at `/android-chrome-192x192.png`
- [x] Build with `NEXT_PUBLIC_BASE_PATH=/my-repo` → manifest icons at `/my-repo/android-chrome-192x192.png`
- [ ] On deploy, "Determine base path" step prints the expected value
- [ ] Post-deploy `npm run smoke <url>` shows no 404s (manifest icons reachable; the security.txt fix from #304 also clears)

Stacks on top of `main` after #304 lands (or independently — the only file overlap is `deploy.yml` which #304 also touches; either order works with at most a trivial conflict on the smoke-check step).


---
_Generated by [Claude Code](https://claude.ai/code/session_01G73s7idxoHDUsTPyE8tF8h)_