### PR TITLE
feat(smoke): verify manifest icon URLs actually resolve

### DIFF
--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -188,6 +188,25 @@ async function smoke() {
         'manifest has theme_color or background_color',
         !!(manifest.theme_color || manifest.background_color)
       )
+      // Verify every icon URL the manifest advertises actually resolves.
+      // Catches the bug fixed in #319: a custom-domain deploy with
+      // NEXT_PUBLIC_BASE_PATH=/repo would emit icon srcs like
+      // /repo/android-chrome-192x192.png that 404 on the root-served
+      // custom domain. The PWA install prompt fails silently otherwise.
+      if (Array.isArray(manifest.icons)) {
+        for (const icon of manifest.icons) {
+          if (!icon?.src) continue
+          const iconUrl = icon.src.startsWith('http')
+            ? icon.src
+            : icon.src.startsWith('/')
+              ? icon.src
+              : `/${icon.src}`
+          const iconPath = iconUrl.startsWith('http') ? iconUrl.replace(BASE, '') : iconUrl
+          const r = await fetchWithRetry(iconPath).catch(() => null)
+          const ok = r && r.status === 200
+          record(`manifest icon ${icon.src} resolves`, ok, r ? `HTTP ${r.status}` : 'fetch failed')
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Extends `scripts/smoke-check.mjs` (from #304) to fetch every `icons[].src` the manifest advertises and verify each resolves.

## Why

The bug fixed in #319 was: a custom-domain deploy with `NEXT_PUBLIC_BASE_PATH=/<repo>` emits manifest icon srcs like `/<repo>/android-chrome-192x192.png`, but the deployed site serves from root, so those paths 404. The PWA install prompt then silently falls back to default icons. The previous smoke check verified the manifest itself returned 200 + valid JSON but never followed the icon URLs it advertised, so the bug shipped undetected.

## Verified locally against the live site (still pre-#319 deploy)

```
✗ manifest icon /FFC_Single_Page_Template/android-chrome-192x192.png resolves — HTTP 404
✗ manifest icon /FFC_Single_Page_Template/android-chrome-512x512.png resolves — HTTP 404
```

The new check correctly surfaces both broken icon paths. Once #319 deploys, this check will go green on its own.

## Verification

- `npm run format` clean
- `npm run check:drift` 0 errors
- `npm test` 41/41
- `npm run build` clean
- Live smoke against ffcworkingsite1.org shows the new failures (correct — they're the bug #319 fixes)

Depends on #304 (already merged) which introduced `scripts/smoke-check.mjs`. Independent of #319 — they can land in either order; together they form an end-to-end guarantee that PWA icons resolve on every deploy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G73s7idxoHDUsTPyE8tF8h)_