### PR TITLE
fix(ci): unblock the deploy pipeline (cancellation + flaky E2E)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,15 @@ on:
   # Allows manual trigger from Actions tab
   workflow_dispatch:
 
-# Cancel in-progress CI runs for the same PR/branch
+# Cancel in-progress CI runs ONLY for pull requests (a new push to a PR
+# supersedes the old run). NEVER cancel on main pushes: deploy.yml fires
+# via `workflow_run` only when this workflow concludes `success`, so a
+# cancelled main run (which concludes `cancelled`) silently skips the
+# deploy. A rapid merge train would otherwise cancel each commit's CI
+# and leave production stuck on a stale build.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test-and-build:

--- a/tests/application-form.spec.ts
+++ b/tests/application-form.spec.ts
@@ -43,10 +43,19 @@ test.describe('Application Form Button', () => {
   })
 
   test('should display loading indicator before iframe loads', async ({ page }) => {
-    // Click the button
+    // Hold the Microsoft Forms iframe request open so its onLoad handler can't
+    // fire during the assertion window — that keeps isLoading=true and the
+    // indicator visible deterministically. Aborting doesn't work: Chromium
+    // fires onLoad for a failed iframe, hiding the indicator. Without this the
+    // test raced the live forms.office.com load and flaked in CI, which
+    // blocked the deploy pipeline.
+    await page.route('**/forms.office.com/**', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 10000))
+      await route.abort().catch(() => {}) // page may already be closed at teardown
+    })
+
     await page.getByRole('button', { name: testConfig.applicationForm.buttonText }).click()
 
-    // Loading indicator should be visible initially
     const loadingIndicator = page.getByText(testConfig.applicationForm.loadingText)
     await expect(loadingIndicator).toBeVisible()
   })
@@ -252,23 +261,26 @@ test.describe('Application Form Iframe Loading', () => {
   })
 
   test('should display loading indicator and iframe elements', async ({ page }) => {
-    // Open modal
+    // Hold the iframe request open so onLoad can't fire and hide the
+    // indicator during the assertion (see the sibling test for why aborting
+    // doesn't work). Removes the dependency on live forms.office.com timing.
+    await page.route('**/forms.office.com/**', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 10000))
+      await route.abort().catch(() => {})
+    })
+
     await page.getByRole('button', { name: testConfig.applicationForm.buttonText }).click()
 
     const modal = page.locator('[role="dialog"][aria-modal="true"]')
     await expect(modal).toBeVisible()
 
-    // Loading indicator should be visible initially
+    // Loading indicator should be visible (iframe load is blocked above).
     const loadingIndicator = page.getByText(testConfig.applicationForm.loadingText)
     await expect(loadingIndicator).toBeVisible()
 
-    // Verify iframe element exists
+    // The iframe element itself should exist in the DOM (its src points at
+    // the Microsoft Form; we don't require the remote content to load).
     const iframe = page.locator(`iframe[title="${testConfig.applicationForm.modalTitle}"]`)
     await expect(iframe).toBeVisible()
-
-    // Note: The loading indicator behavior is environment-dependent.
-    // In some environments (especially CI), external iframes may be blocked by privacy settings,
-    // causing the loading indicator to remain visible. This test verifies the component structure
-    // is correct (both loading indicator and iframe are present), not the iframe loading behavior.
   })
 })

--- a/tests/google-tag-manager.spec.ts
+++ b/tests/google-tag-manager.spec.ts
@@ -10,14 +10,40 @@ import { testConfig } from './test.config'
  * 3. GTM noscript fallback exists in body
  * 4. GTM ID is configured in the component
  *
+ * IMPORTANT: the GTM <Script> uses Next.js `strategy="lazyOnload"`, which
+ * injects the script element and runs the inline bootstrap only AFTER the
+ * page `load` event and a browser-idle tick. Asserting immediately after
+ * page.goto() is therefore racy — the element/dataLayer may not exist yet.
+ * Every test below waits for the deferred injection with a bounded timeout
+ * instead of checking synchronously. This keeps them deterministic in CI
+ * (where a slow idle callback previously caused flaky failures that blocked
+ * the deploy pipeline) without depending on the live googletagmanager.com
+ * fetch.
+ *
  * Note: Test expectations use values from test.config.ts for easy customization
  */
+
+// Wait for the lazyOnload GTM script element to be attached to the DOM.
+async function waitForGtmScript(page: import('@playwright/test').Page) {
+  await page.waitForSelector('script#gtm-script', { state: 'attached', timeout: 15000 })
+}
+
+// Wait for the inline bootstrap to have created window.dataLayer.
+async function waitForDataLayer(page: import('@playwright/test').Page) {
+  await page.waitForFunction(
+    () => typeof window.dataLayer !== 'undefined' && Array.isArray(window.dataLayer),
+    null,
+    {
+      timeout: 15000,
+    }
+  )
+}
 
 test.describe('Google Tag Manager Integration', () => {
   test('should initialize dataLayer on page load', async ({ page }) => {
     await page.goto('/')
+    await waitForDataLayer(page)
 
-    // Check if dataLayer exists and is initialized
     const hasDataLayer = await page.evaluate(() => {
       return typeof window.dataLayer !== 'undefined' && Array.isArray(window.dataLayer)
     })
@@ -27,12 +53,11 @@ test.describe('Google Tag Manager Integration', () => {
 
   test('should load GTM script with correct ID', async ({ page }) => {
     await page.goto('/')
+    await waitForGtmScript(page)
 
-    // Check for GTM script element
     const gtmScript = await page.locator('script[id="gtm-script"]').count()
     expect(gtmScript).toBeGreaterThan(0)
 
-    // Verify script contains GTM initialization code
     const scriptContent = await page.locator('script[id="gtm-script"]').innerHTML()
     expect(scriptContent).toContain('googletagmanager.com/gtm.js')
     expect(scriptContent).toContain('dataLayer')
@@ -41,8 +66,8 @@ test.describe('Google Tag Manager Integration', () => {
   test('should have GTM noscript fallback in body', async ({ page }) => {
     await page.goto('/')
 
-    // Check for noscript iframe element
-    // We verify it exists in the HTML even though it won't render with JavaScript enabled
+    // The noscript iframe is server-rendered, so it's present immediately —
+    // no need to wait for the lazyOnload script.
     const pageContent = await page.content()
     expect(pageContent).toContain('googletagmanager.com/ns.html')
     expect(pageContent).toContain('noscript')
@@ -50,8 +75,8 @@ test.describe('Google Tag Manager Integration', () => {
 
   test('should push events to dataLayer', async ({ page }) => {
     await page.goto('/')
+    await waitForDataLayer(page)
 
-    // Verify we can push events to dataLayer
     const canPushToDataLayer = await page.evaluate(() => {
       if (typeof window.dataLayer === 'undefined') return false
 
@@ -65,22 +90,18 @@ test.describe('Google Tag Manager Integration', () => {
 
   test('should load GTM script after page interaction', async ({ page }) => {
     await page.goto('/')
+    await waitForGtmScript(page)
+    await waitForDataLayer(page)
 
-    // Verify GTM script exists on the page
-    // Note: Next.js Script component with lazyOnload strategy
-    // defers script loading until after page is interactive
     const gtmScript = await page.evaluate(() => {
       const script = document.querySelector('script[id="gtm-script"]')
       return script !== null
     })
-
     expect(gtmScript).toBe(true)
 
-    // Verify dataLayer is initialized (may be delayed with lazyOnload)
     const dataLayerInitialized = await page.evaluate(() => {
       return typeof window.dataLayer !== 'undefined'
     })
-
     expect(dataLayerInitialized).toBe(true)
   })
 
@@ -114,16 +135,12 @@ test.describe('Google Tag Manager Configuration', () => {
   test('should load GTM script with configured ID', async ({ page }) => {
     // This test verifies that GTM loads with the configured ID from test.config.ts
     // The GTM_ID is configured in the component
-
     await page.goto('/')
+    await waitForGtmScript(page)
 
-    // GTM script should always be present with the configured ID
     const gtmScript = await page.locator('script[id="gtm-script"]').count()
-
-    // Script should be present
     expect(gtmScript).toBeGreaterThan(0)
 
-    // Verify the script contains the correct GTM ID
     const scriptContent = await page.locator('script[id="gtm-script"]').innerHTML()
     expect(scriptContent).toContain(testConfig.googleTagManager.id)
   })

--- a/tests/google-tag-manager.spec.ts
+++ b/tests/google-tag-manager.spec.ts
@@ -24,18 +24,22 @@ import { testConfig } from './test.config'
  */
 
 // Wait for the lazyOnload GTM script element to be attached to the DOM.
+// lazyOnload fires after the window `load` event + a browser-idle tick, so
+// we explicitly wait for `load` first, then poll for the injected element
+// with a generous timeout (CI runners can be slow to fire load when many
+// third-party resources are in flight).
 async function waitForGtmScript(page: import('@playwright/test').Page) {
-  await page.waitForSelector('script#gtm-script', { state: 'attached', timeout: 15000 })
+  await page.waitForLoadState('load')
+  await page.waitForSelector('script#gtm-script', { state: 'attached', timeout: 30000 })
 }
 
 // Wait for the inline bootstrap to have created window.dataLayer.
 async function waitForDataLayer(page: import('@playwright/test').Page) {
+  await page.waitForLoadState('load')
   await page.waitForFunction(
     () => typeof window.dataLayer !== 'undefined' && Array.isArray(window.dataLayer),
     null,
-    {
-      timeout: 15000,
-    }
+    { timeout: 30000 }
   )
 }
 


### PR DESCRIPTION
## Why your stuff isn't on the live site — two root causes, both fixed here

Your merges all landed on `main`, but the deploy never ran. There were **two** independent reasons, and this PR fixes both.

### 1. CI cancellation skipped deploys (commit 1)

`ci.yml` used `cancel-in-progress: true` keyed on `github.ref`. For PRs that's correct, but on `main` every push shares one group, so today's rapid merge train cancelled each commit's CI. `deploy.yml` only deploys when CI concludes `success`; a **cancelled** run concludes `cancelled` → deploy job's `if` evaluated false → **skipped**. Confirmed via check-runs API:

```
db2fdc8  Test and Build → cancelled   Deploy to GitHub Pages → skipped
1aebebc  Test and Build → cancelled   Deploy to GitHub Pages → skipped
```

**Fix:** `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — PRs still cancel their own superseded runs; `main` always runs CI to completion.

### 2. Flaky E2E failed CI even when it ran (commit 2)

Even when `main` CI ran to completion, 7 E2E tests failed intermittently → CI `failure` → deploy skipped anyway. (This PR's own first CI run hit it — `Test and Build → failure`.)

- **5 GTM tests** asserted synchronously right after `page.goto()`, but the GTM `<Script>` uses `strategy="lazyOnload"` and injects after the load event + idle tick. Added bounded `waitForGtmScript()` / `waitForDataLayer()` waits. No dependency on the live `googletagmanager.com` fetch.
- **2 application-form tests** asserted the loading indicator is visible, racing the live `forms.office.com` iframe load (Chromium fires `onLoad` fast, flipping `isLoading=false`). The route handler now **holds the iframe request open** so `onLoad` can't fire during the assertion — deterministic, no live dependency.

**Verified locally:** full E2E suite `75 passed / 1 skipped / 0 failed` with `CI=true` (2 retries), zero flaky retries consumed.

## Result

Once this merges, its own `main` CI run completes `success` (deterministic E2E, no cancellation) → `workflow_run` fires `deploy.yml` → production finally picks up the entire day's work (auto-basePath, `/security.txt` fallback, theme-color, manifest icon verification, etc.). The post-deploy smoke check (`scripts/smoke-check.mjs`) validates it.

## Verification

- `npm run check:drift` 0 errors
- `CI=true npx playwright test` — 75 passed, 1 skipped, 0 failed
- Only CI config + test files touched; no app code changed
