### PR TITLE
fix(ci): check links against served output to fix clean-URL false 404s

### DIFF
--- a/EXTERNAL_DEPENDENCIES.md
+++ b/EXTERNAL_DEPENDENCIES.md
@@ -104,7 +104,7 @@ These are services we directly integrate into our application code.
 - **Domain:** `www.zeffy.com`
 - **Preconnect:** Configured in `src/app/layout.tsx`
 - **Data Collected:** Donation transaction data
-- **Privacy Policy:** https://www.zeffy.com/privacy
+- **Privacy Policy:** https://support.zeffy.com/legal-data-privacy-security
 
 ### Transparency & Validation
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "check-links": "linkinator ./out --recurse --config .linkinatorrc.json",
+    "check-links": "node scripts/check-links.mjs",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -16,7 +16,7 @@
 import { createServer } from 'node:http'
 import { spawn } from 'node:child_process'
 import { readFile, stat } from 'node:fs/promises'
-import { join, normalize, extname } from 'node:path'
+import { join, normalize, extname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = fileURLToPath(new URL('../out', import.meta.url))
@@ -44,19 +44,29 @@ const CONTENT_TYPES = {
 }
 
 async function resolveFile(urlPath) {
-  // Strip query/hash, decode, drop any trailing slash, and prevent path
-  // traversal outside ROOT. A trailing slash is irrelevant to resolution —
-  // `/privacy-policy` and `/privacy-policy/` resolve identically, just as
-  // GitHub Pages (and the `serve` preview) treat them.
-  const clean = decodeURIComponent(urlPath.split('?')[0].split('#')[0])
-  const trimmed = clean.replace(/\/+$/, '')
-  const safe = normalize(trimmed).replace(/^(\.\.[/\\])+/, '')
-  const base = join(ROOT, safe)
+  // Strip query/hash and decode. decodeURIComponent throws on malformed
+  // escapes (e.g. a bare `%`), so guard it rather than crash the handler.
+  let decoded
+  try {
+    decoded = decodeURIComponent(urlPath.split('?')[0].split('#')[0])
+  } catch {
+    return null
+  }
+
+  // Drop leading slashes so the request always resolves *relative* to ROOT
+  // (an absolute-looking path like `/etc/passwd` must not escape it), and a
+  // trailing slash is irrelevant — `/privacy-policy` and `/privacy-policy/`
+  // resolve identically, just as GitHub Pages and the `serve` preview treat
+  // them.
+  const rel = normalize(decoded.replace(/^[/\\]+/, '').replace(/\/+$/, ''))
+  const base = resolve(ROOT, rel)
+  // Defense in depth: never serve anything resolved outside ROOT.
+  if (base !== ROOT && !base.startsWith(ROOT + sep)) return null
 
   // Resolution order mirrors GitHub Pages for `output: 'export'`:
   // exact file, then `<path>.html` (clean URL), then `<path>/index.html`.
   const candidates =
-    safe === '' || safe === '.'
+    rel === '' || rel === '.'
       ? [join(ROOT, 'index.html')]
       : [base, `${base}.html`, join(base, 'index.html')]
 
@@ -105,8 +115,13 @@ server.listen(0, '127.0.0.1', () => {
     '--config',
     fileURLToPath(new URL('../.linkinatorrc.json', import.meta.url)),
   ]
-  const bin = fileURLToPath(new URL('../node_modules/.bin/linkinator', import.meta.url))
-  const child = spawn(bin, args, { stdio: 'inherit' })
+  // Spawn linkinator from PATH — npm puts node_modules/.bin on PATH for
+  // scripts, so `npm run check-links` resolves it cross-platform. shell:true
+  // on Windows lets the `linkinator.cmd` shim resolve.
+  const child = spawn('linkinator', args, {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  })
   child.on('exit', (code) => shutdown(code ?? 1))
   child.on('error', (err) => {
     console.error('Failed to run linkinator:', err)

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,115 @@
+// Link checker that mirrors how GitHub Pages serves the static export.
+//
+// Why this exists: `next build` (output: 'export') emits clean-URL pages as
+// `out/<route>.html`, while internal links use extensionless clean URLs
+// (e.g. `href="/privacy-policy"`). Next also emits a sibling directory
+// `out/<route>/` containing RSC prefetch payloads (`__next.*.txt`) with no
+// `index.html`. Running linkinator directly against the `./out` *filesystem*
+// resolves `/privacy-policy` to that index-less directory and reports a false
+// 404 — even though GitHub Pages serves `privacy-policy.html` for that path.
+//
+// To check links the way the deployed site actually behaves, we serve `out/`
+// over HTTP with GitHub-Pages-style resolution (try the path, then `.html`,
+// then `/index.html`) and point linkinator at the URL. Real missing routes
+// still return 404, so genuine broken links are still caught.
+
+import { createServer } from 'node:http'
+import { spawn } from 'node:child_process'
+import { readFile, stat } from 'node:fs/promises'
+import { join, normalize, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = fileURLToPath(new URL('../out', import.meta.url))
+
+const CONTENT_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+async function resolveFile(urlPath) {
+  // Strip query/hash, decode, drop any trailing slash, and prevent path
+  // traversal outside ROOT. A trailing slash is irrelevant to resolution —
+  // `/privacy-policy` and `/privacy-policy/` resolve identically, just as
+  // GitHub Pages (and the `serve` preview) treat them.
+  const clean = decodeURIComponent(urlPath.split('?')[0].split('#')[0])
+  const trimmed = clean.replace(/\/+$/, '')
+  const safe = normalize(trimmed).replace(/^(\.\.[/\\])+/, '')
+  const base = join(ROOT, safe)
+
+  // Resolution order mirrors GitHub Pages for `output: 'export'`:
+  // exact file, then `<path>.html` (clean URL), then `<path>/index.html`.
+  const candidates =
+    safe === '' || safe === '.'
+      ? [join(ROOT, 'index.html')]
+      : [base, `${base}.html`, join(base, 'index.html')]
+
+  for (const candidate of candidates) {
+    try {
+      const info = await stat(candidate)
+      if (info.isFile()) return candidate
+    } catch {
+      // try next candidate
+    }
+  }
+  return null
+}
+
+const server = createServer(async (req, res) => {
+  const file = await resolveFile(req.url || '/')
+  if (!file) {
+    res.statusCode = 404
+    res.end('Not found')
+    return
+  }
+  try {
+    const body = await readFile(file)
+    res.statusCode = 200
+    res.setHeader('Content-Type', CONTENT_TYPES[extname(file)] || 'application/octet-stream')
+    res.end(body)
+  } catch {
+    res.statusCode = 500
+    res.end('Server error')
+  }
+})
+
+function shutdown(code) {
+  server.close(() => process.exit(code))
+  // Safety net: don't hang the job if a socket lingers.
+  setTimeout(() => process.exit(code), 2000).unref()
+}
+
+// Listen on an ephemeral port to avoid collisions in CI.
+server.listen(0, '127.0.0.1', () => {
+  const { port } = server.address()
+  const target = `http://127.0.0.1:${port}`
+  const args = [
+    target,
+    '--recurse',
+    '--config',
+    fileURLToPath(new URL('../.linkinatorrc.json', import.meta.url)),
+  ]
+  const bin = fileURLToPath(new URL('../node_modules/.bin/linkinator', import.meta.url))
+  const child = spawn(bin, args, { stdio: 'inherit' })
+  child.on('exit', (code) => shutdown(code ?? 1))
+  child.on('error', (err) => {
+    console.error('Failed to run linkinator:', err)
+    shutdown(1)
+  })
+})

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -193,12 +193,12 @@ export default function CookiePolicy() {
             <p className="text-xs mt-2 text-gray-600">
               Privacy Policy:{' '}
               <a
-                href="https://www.zeffy.com/privacy"
+                href="https://support.zeffy.com/legal-data-privacy-security"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 hover:underline"
               >
-                https://www.zeffy.com/privacy
+                https://support.zeffy.com/legal-data-privacy-security
               </a>
             </p>
           </div>


### PR DESCRIPTION
## Summary

Fixes the long-standing `Link check (soft-fail)` noise: 7 false 404s on every run.

**Root cause:** `npm run check-links` ran `linkinator ./out --recurse` against the **filesystem**. `next build` (`output: 'export'`) emits clean-URL pages as `out/<route>.html` plus a sibling `out/<route>/` directory of RSC payloads (`__next.*.txt`) with **no `index.html`**. Internal links are extensionless (`/privacy-policy`), so linkinator resolved them to the index-less directory and returned false 404s — even though GitHub Pages serves `<route>.html` for those paths.

## What changed

- **`scripts/check-links.mjs`** (new): a tiny dependency-free static server that serves `out/` with **GitHub-Pages-style resolution** (path → `.html` → `/index.html`, trailing slash ignored), then runs `linkinator` against the URL. Genuine 404s still fail, so real broken links are still caught. No new dependencies (uses the existing `linkinator` devDependency and Node's built-in `http`).
- **`package.json`**: `check-links` now runs the script.
- **Real broken link fixed:** the accurate checker surfaced `https://www.zeffy.com/privacy` (404) on the cookie-policy page. Repointed to Zeffy's current legal/privacy page `https://support.zeffy.com/legal-data-privacy-security` (verified 200), and updated the matching entry in `EXTERNAL_DEPENDENCIES.md`.

## Verification

```
npm run build && npm run check-links
→ ✓ Successfully scanned 89 links   (exit 0, zero broken)
```

- `npm test` — 98/98 passing
- `npm run check:drift` — ✅ no drift
- Pre-commit hook (format/lint/drift) — green (lint: 7 pre-existing warnings, 0 errors)

## Follow-up

With the false positives gone and the job green, `Link check` can be flipped from `continue-on-error: true` to a hard gate as envisioned in #289. Left as soft-fail here to avoid PR-blocking flakiness from transient external-link outages — that policy flip can be a separate decision.

Fixes #334
Refs #289

https://claude.ai/code/session_01C1qTeyp9ue9Ku9dTGgGHZr

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1qTeyp9ue9Ku9dTGgGHZr)_