### PR TITLE
ci(deploy): bump GitHub Pages actions to latest majors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
@@ -89,7 +89,7 @@ jobs:
           NEXT_PUBLIC_BASE_PATH: ${{ steps.basepath.outputs.value }}
 
       - name: Upload artifact for Pages
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Checkout (for smoke-check script)
         uses: actions/checkout@v6
@@ -134,7 +134,7 @@ jobs:
       issues: write
     steps:
       - name: Create incident issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,11 +119,26 @@ jobs:
           DEPLOY_URL: ${{ steps.deployment.outputs.page_url }}
         timeout-minutes: 5
         # Runs scripts/smoke-check.mjs against the freshly deployed URL.
-        # Verifies the home page, security.txt (with /.well-known fallback to
-        # /), robots.txt, sitemap.xml, manifest, branded 404, and favicons.
+        # Verifies the home page, its same-origin sub-resources (CSS/JS),
+        # security.txt (with /.well-known fallback to /), robots.txt,
+        # sitemap.xml, manifest, branded 404, and favicons.
         # The script lives in the repo so it's runnable locally too:
         #   node scripts/smoke-check.mjs https://your-site.example
-        run: node scripts/smoke-check.mjs "$DEPLOY_URL"
+        #
+        # When public/CNAME is present we also pass PROD_URL = the live custom
+        # domain. The script then verifies the build works when served at the
+        # apex ROOT (not just the deploy URL) — the only check that catches a
+        # basePath/custom-domain mismatch. That pass is fail-soft about
+        # reachability (DNS/TLS propagation, first deploys), so it only fails on
+        # a definitive mismatch (200 home whose own assets 404).
+        run: |
+          PROD_URL=""
+          if [ -s "public/CNAME" ]; then
+            cname="$(tr -d '[:space:]' < public/CNAME)"
+            if [ -n "$cname" ]; then PROD_URL="https://${cname}/"; fi
+          fi
+          echo "DEPLOY_URL=$DEPLOY_URL  PROD_URL=${PROD_URL:-<none>}"
+          PROD_URL="$PROD_URL" node scripts/smoke-check.mjs "$DEPLOY_URL"
 
   notify-failure:
     name: Notify on production deploy failure
@@ -278,3 +293,4 @@ jobs:
             }
 
             core.info(`Created incident issue #${created.data.number}`);
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -293,4 +293,3 @@ jobs:
             }
 
             core.info(`Created incident issue #${created.data.number}`);
-

--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -256,7 +256,9 @@ async function smoke() {
     } catch {
       /* keep BASE */
     }
-    const refs = [...new Set(extractSubresourceUrls(homeHtml).filter((u) => isSameOrigin(u, originBase)))]
+    const refs = [
+      ...new Set(extractSubresourceUrls(homeHtml).filter((u) => isSameOrigin(u, originBase))),
+    ]
     const sample = refs.slice(0, 30)
     let bad = 0
     for (const ref of sample) {
@@ -335,7 +337,9 @@ async function smoke() {
     try {
       prodHome = await fetchProd(`${PROD}/`)
     } catch (err) {
-      warn(`prod ${PROD} not reachable yet (${(err && err.message) || err}) — skipping prod asset check`)
+      warn(
+        `prod ${PROD} not reachable yet (${(err && err.message) || err}) — skipping prod asset check`
+      )
     }
     if (prodHome && prodHome.status === 200) {
       const phtml = await prodHome.text()
@@ -367,7 +371,9 @@ async function smoke() {
         pbad === 0 ? `${prefs.length} ok` : `${pbad}/${prefs.length} broken: ${broken.join(', ')}`
       )
     } else if (prodHome) {
-      warn(`prod ${PROD} home returned HTTP ${prodHome.status} — skipping prod asset check (propagation?)`)
+      warn(
+        `prod ${PROD} home returned HTTP ${prodHome.status} — skipping prod asset check (propagation?)`
+      )
     }
   }
 
@@ -385,4 +391,3 @@ smoke().catch((err) => {
   console.error('\nSmoke check crashed:', err && err.stack ? err.stack : err)
   process.exit(1)
 })
-

--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -32,6 +32,15 @@ if (!baseArg) {
   process.exit(2)
 }
 const BASE = baseArg.replace(/\/$/, '')
+// Deploy base path, e.g. '' on a custom domain or '/<repo>' on a github.io
+// project deploy. Used to de-dupe sub-resource paths that already include it.
+const BASE_PATHNAME = (() => {
+  try {
+    return new URL(BASE).pathname.replace(/\/+$/, '')
+  } catch {
+    return ''
+  }
+})()
 
 const TOTAL_DEADLINE_MS = 180 * 1000
 const REQUEST_TIMEOUT_MS = 15 * 1000

--- a/scripts/smoke-check.mjs
+++ b/scripts/smoke-check.mjs
@@ -90,13 +90,47 @@ async function expect200(path, name = path) {
   }
 }
 
+// Non-fatal note: logged but never added to results, so it can't fail the run.
+function warn(msg) {
+  console.log(`! ${msg}`)
+}
+
+// Extract the URLs the home page needs in order to actually render:
+// stylesheets, (module)preloads, and scripts. Used to catch "page is 200 but
+// its assets 404" — the whole-bundle blind spot the fixed per-file checks miss.
+function extractSubresourceUrls(html) {
+  const urls = []
+  let m
+  const linkRe = /<link\b[^>]*?\bhref=["']([^"']+)["'][^>]*>/gi
+  while ((m = linkRe.exec(html))) {
+    if (/\brel=["'](?:stylesheet|preload|modulepreload)["']/i.test(m[0])) urls.push(m[1])
+  }
+  const scriptRe = /<script\b[^>]*?\bsrc=["']([^"']+)["'][^>]*>/gi
+  while ((m = scriptRe.exec(html))) urls.push(m[1])
+  return urls
+}
+
+// Same-origin guard: root-relative paths are same-origin by definition; absolute
+// URLs must match `origin`. Cross-origin assets (font/analytics CDNs) are skipped
+// so a flaky or rate-limiting third party can never fail a deploy.
+function isSameOrigin(url, origin) {
+  if (/^\/(?!\/)/.test(url)) return true
+  try {
+    return new URL(url).origin === origin
+  } catch {
+    return false
+  }
+}
+
 async function smoke() {
   console.log(`Smoke checking ${BASE}\n`)
 
   // 1. Home page.
+  let homeHtml = ''
   const homeRes = await expect200('/', 'home page returns 200')
   if (homeRes) {
     const html = await homeRes.text()
+    homeHtml = html
     record(
       'home has Content-Security-Policy <meta>',
       /<meta[^>]+http-equiv=["']Content-Security-Policy["'][^>]+content=/i.test(html)
@@ -210,6 +244,39 @@ async function smoke() {
     }
   }
 
+  // 4b. Same-origin sub-resources the home page references actually load.
+  // The per-file checks above only cover a fixed list; this covers the real
+  // CSS/JS bundle. Run against BASE (the deploy URL), so it validates the
+  // build is self-consistent at its own deploy URL. Capped + de-duped to bound
+  // request volume; same-origin only.
+  if (homeHtml) {
+    let originBase = BASE
+    try {
+      originBase = new URL(BASE).origin
+    } catch {
+      /* keep BASE */
+    }
+    const refs = [...new Set(extractSubresourceUrls(homeHtml).filter((u) => isSameOrigin(u, originBase)))]
+    const sample = refs.slice(0, 30)
+    let bad = 0
+    for (const ref of sample) {
+      // Normalize to a BASE-relative path, mirroring the manifest-icon logic so
+      // the deploy base path isn't doubled on a github.io subpath deploy.
+      let p = ref.startsWith('http') ? new URL(ref).pathname : ref
+      if (BASE_PATHNAME && p.startsWith(`${BASE_PATHNAME}/`)) p = p.slice(BASE_PATHNAME.length)
+      const r = await fetchWithRetry(p).catch(() => null)
+      if (!r || r.status !== 200) {
+        bad++
+        record(`sub-resource ${ref}`, false, r ? `HTTP ${r.status}` : 'fetch failed')
+      }
+    }
+    record(
+      'home sub-resources (same-origin) resolve',
+      bad === 0,
+      `${sample.length - bad}/${sample.length} ok${refs.length > sample.length ? ` (capped from ${refs.length})` : ''}`
+    )
+  }
+
   // 5. Branded 404.
   const notFoundUrl = `/this-page-definitely-does-not-exist-${Date.now()}`
   const notFoundRes = await fetchWithRetry(notFoundUrl).catch(() => null)
@@ -231,6 +298,79 @@ async function smoke() {
   await expect200('/favicon.ico')
   await expect200('/icon.png')
 
+  // 6b. Optional production-domain pass (best effort). Set PROD_URL to the live
+  // custom domain (e.g. https://example.org/) to verify the build also works
+  // when served at the apex *root*, not just at its deploy URL. This is the ONLY
+  // check that catches a basePath/custom-domain mismatch.
+  //
+  // It is deliberately fail-SOFT about reachability: a freshly-attached domain
+  // may not have DNS/TLS yet, and a brand-new site's first deploy may have no
+  // custom domain at all. We therefore only FAIL on a *definitive* mismatch —
+  // the prod home serving HTTP 200 while its own same-origin sub-resources 404.
+  // If prod is unreachable, cert-not-ready, or non-200, we warn and move on, so
+  // propagation lag never reds an otherwise-good deploy.
+  const prodUrl = (process.env.PROD_URL || '').trim()
+  if (prodUrl) {
+    const PROD = prodUrl.replace(/\/$/, '')
+    let prodOrigin = PROD
+    try {
+      prodOrigin = new URL(PROD).origin
+    } catch {
+      /* keep PROD */
+    }
+    const fetchProd = async (target) => {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+      try {
+        return await fetch(target, {
+          signal: controller.signal,
+          redirect: 'follow',
+          headers: { 'User-Agent': 'ffc-smoke-check' },
+        })
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+    let prodHome = null
+    try {
+      prodHome = await fetchProd(`${PROD}/`)
+    } catch (err) {
+      warn(`prod ${PROD} not reachable yet (${(err && err.message) || err}) — skipping prod asset check`)
+    }
+    if (prodHome && prodHome.status === 200) {
+      const phtml = await prodHome.text()
+      // No base-path stripping here: fetch the literal href against the prod
+      // origin, so a /<repo>/... asset will 404 at the apex root and be caught.
+      const prefs = [
+        ...new Set(extractSubresourceUrls(phtml).filter((u) => isSameOrigin(u, prodOrigin))),
+      ].slice(0, 30)
+      let pbad = 0
+      const broken = []
+      for (const ref of prefs) {
+        const target = ref.startsWith('http')
+          ? ref
+          : `${prodOrigin}${ref.startsWith('/') ? '' : '/'}${ref}`
+        let r = null
+        try {
+          r = await fetchProd(target)
+        } catch {
+          /* treated as failure below */
+        }
+        if (!r || r.status !== 200) {
+          pbad++
+          if (broken.length < 5) broken.push(`${ref} -> ${r ? r.status : 'ERR'}`)
+        }
+      }
+      record(
+        `prod ${PROD} serves its own home assets`,
+        pbad === 0,
+        pbad === 0 ? `${prefs.length} ok` : `${pbad}/${prefs.length} broken: ${broken.join(', ')}`
+      )
+    } else if (prodHome) {
+      warn(`prod ${PROD} home returned HTTP ${prodHome.status} — skipping prod asset check (propagation?)`)
+    }
+  }
+
   // 7. Summary.
   const failed = results.filter((r) => !r.ok)
   console.log(`\n${results.length - failed.length}/${results.length} checks passed`)
@@ -245,3 +385,4 @@ smoke().catch((err) => {
   console.error('\nSmoke check crashed:', err && err.stack ? err.stack : err)
   process.exit(1)
 })
+


### PR DESCRIPTION
## Summary

Bumps the GitHub-maintained Pages actions in `.github/workflows/deploy.yml` to their current major versions. These actions are released in lockstep, so they're bumped together to stay compatible.

| Action | Before | After |
|--------|--------|-------|
| `actions/configure-pages` | v5 | **v6** |
| `actions/upload-pages-artifact` | v4 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |
| `actions/github-script` | v8 | **v9** |

`actions/checkout@v6`, `actions/setup-node@v6`, and `actions/cache@v5` were already current and are unchanged.

## Notes

- Pure CI/workflow version bumps; no application code touched.
- `github-script@v9` runs on the Node 24 runtime; the inline script uses only stable `github.rest.*` / `core.*` APIs.
- Opened as **draft** so a maintainer can run the deploy workflow and confirm Pages still publishes before merge.

https://claude.ai/code/session_0133wZ4hhb7PU4k9dXX5xRkx---

## Also: harden the post-deploy smoke check

A live `hclwellness.org` deploy rendered as an unstyled, broken page (every CSS/JS/font/image 404'd) **after** a green smoke check. Root cause: the build used `NEXT_PUBLIC_BASE_PATH=/<repo>` (subpath) but the site was served at the apex root, so all assets 404'd — yet the smoke check only ran against the github.io **deploy URL** (where the subpath build is self-consistent) and only verified a fixed list of *files* returned 200; it never fetched the home page's actual CSS/JS bundle.

**Changes (`scripts/smoke-check.mjs` + `deploy.yml`):**
- Parse the home HTML and assert every **same-origin** `<link rel=stylesheet|preload|modulepreload>` and `<script src>` returns 200 (de-duped, capped at 30).
- Optional **`PROD_URL`** pass (wired from `public/CNAME` in `deploy.yml`): verifies the build works when served at the apex **root** — the only check that can catch a basePath/custom-domain mismatch.

**⚠️ Why the prod pass is deliberately fail-SOFT (safety):** testing the live domain couples the deploy gate to DNS + TLS propagation and edge availability. A brand-new domain may not resolve / have a cert yet, and a site's first deploy may have no custom domain at all — a strict apex check would red good deploys and fire the `notify-failure` incident automation. So the prod pass **only fails on a definitive mismatch** (prod home serves HTTP 200 but its *own* same-origin sub-resources 404); if prod is unreachable / cert-not-ready / non-200 it logs a warning and moves on. Cross-origin assets (font/analytics CDNs) are skipped entirely so a flaky third party can never fail a deploy.