### PR TITLE
feat: add site trust profile contract

### DIFF
--- a/__tests__/lib/site.config.test.ts
+++ b/__tests__/lib/site.config.test.ts
@@ -25,7 +25,14 @@ describe('site trust profile contract', () => {
       managesSecrets: false,
       productionDnsManagedHere: false,
     })
-    expect(siteTrustProfile.trust.requiredChecks).toContain('npm run build')
+    expect(siteTrustProfile.trust.requiredChecks).toEqual([
+      'npm run format:check',
+      'npm run lint',
+      'npm test',
+      'npm run build',
+      'npm run test:e2e',
+      'npm run check:drift',
+    ])
   })
 
   it('keeps the static public JSON endpoint in sync with the typed profile', () => {
@@ -43,7 +50,7 @@ describe('site trust profile contract', () => {
     const serialized = JSON.stringify(profile).toLowerCase()
     expect(serialized).not.toContain('apikey')
     expect(serialized).not.toContain('token')
-    expect(profile.canonicalUrl).toBe(siteConfig.url)
+    expect(profile.canonicalUrl).toBe(siteConfig.url.replace(/\/$/, ''))
     expect(profile.contacts.primaryEmail).toBe(siteConfig.contactEmail)
   })
 
@@ -54,7 +61,7 @@ describe('site trust profile contract', () => {
 
     try {
       siteConfig.name = 'Example Nonprofit'
-      siteConfig.url = 'https://example.org'
+      siteConfig.url = 'https://example.org/'
       siteConfig.contactEmail = 'hello@example.org'
 
       expect(getSiteTrustProfile()).toMatchObject({
@@ -69,6 +76,18 @@ describe('site trust profile contract', () => {
       siteConfig.name = originalName
       siteConfig.url = originalUrl
       siteConfig.contactEmail = originalEmail
+    }
+  })
+
+  it('normalizes canonicalUrl when siteConfig.url has a trailing slash', () => {
+    const originalUrl = siteConfig.url
+
+    try {
+      siteConfig.url = 'https://example.org/'
+
+      expect(getSiteTrustProfile().canonicalUrl).toBe('https://example.org')
+    } finally {
+      siteConfig.url = originalUrl
     }
   })
 })

--- a/__tests__/lib/site.config.test.ts
+++ b/__tests__/lib/site.config.test.ts
@@ -1,4 +1,77 @@
-import { siteConfig, siteUrl, twitterSite, cardDescription } from '../../src/lib/site.config'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  siteConfig,
+  siteTrustProfile,
+  siteUrl,
+  twitterSite,
+  cardDescription,
+  getSiteTrustProfile,
+} from '../../src/lib/site.config'
+
+describe('site trust profile contract', () => {
+  it('exposes the stable v1 machine-readable contract shape', () => {
+    expect(siteTrustProfile.schemaVersion).toBe('ffc.site-profile.v1')
+    expect(siteTrustProfile.profileEndpoints).toEqual({
+      siteProfile: '/site-profile.json',
+      securityTxt: '/.well-known/security.txt',
+      sitemap: '/sitemap.xml',
+      robots: '/robots.txt',
+    })
+    expect(siteTrustProfile.trust).toMatchObject({
+      hosting: 'github-pages-static-export',
+      requiresHttps: true,
+      managesSecrets: false,
+      productionDnsManagedHere: false,
+    })
+    expect(siteTrustProfile.trust.requiredChecks).toContain('npm run build')
+  })
+
+  it('keeps the static public JSON endpoint in sync with the typed profile', () => {
+    const publicProfile = JSON.parse(
+      readFileSync(join(process.cwd(), 'public/site-profile.json'), 'utf8')
+    )
+
+    expect(publicProfile).toEqual(siteTrustProfile)
+  })
+
+  it('returns JSON-serializable public data only', () => {
+    const profile = getSiteTrustProfile()
+    expect(() => JSON.stringify(profile)).not.toThrow()
+    expect(JSON.parse(JSON.stringify(profile))).toEqual(profile)
+    const serialized = JSON.stringify(profile).toLowerCase()
+    expect(serialized).not.toContain('apikey')
+    expect(serialized).not.toContain('token')
+    expect(profile.canonicalUrl).toBe(siteConfig.url)
+    expect(profile.contacts.primaryEmail).toBe(siteConfig.contactEmail)
+  })
+
+  it('reflects siteConfig edits used by generated-site automation', () => {
+    const originalName = siteConfig.name
+    const originalUrl = siteConfig.url
+    const originalEmail = siteConfig.contactEmail
+
+    try {
+      siteConfig.name = 'Example Nonprofit'
+      siteConfig.url = 'https://example.org'
+      siteConfig.contactEmail = 'hello@example.org'
+
+      expect(getSiteTrustProfile()).toMatchObject({
+        siteName: 'Example Nonprofit',
+        canonicalUrl: 'https://example.org',
+        contacts: {
+          primaryEmail: 'hello@example.org',
+          securityEmail: 'hello@example.org',
+        },
+      })
+    } finally {
+      siteConfig.name = originalName
+      siteConfig.url = originalUrl
+      siteConfig.contactEmail = originalEmail
+    }
+  })
+})
 
 describe('siteUrl', () => {
   it('returns the base URL for "/"', () => {

--- a/docs/template-trust-contract.md
+++ b/docs/template-trust-contract.md
@@ -46,7 +46,7 @@ Consumers should treat `schemaVersion` as the compatibility key. Additive fields
   "template": {
     "family": "ffc-single-page-template",
     "repository": "FreeForCharity/FFC-IN-FFC_Single_Page_Template",
-    "branch": "agent/sammy/195-site-profile-contract",
+    "branch": "main",
     "issue": "https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/issues/195"
   },
   "contacts": {
@@ -66,7 +66,14 @@ Consumers should treat `schemaVersion` as the compatibility key. Additive fields
     "requiresHttps": true,
     "managesSecrets": false,
     "productionDnsManagedHere": false,
-    "requiredChecks": ["npm run lint", "npm test", "npm run build"]
+    "requiredChecks": [
+      "npm run format:check",
+      "npm run lint",
+      "npm test",
+      "npm run build",
+      "npm run test:e2e",
+      "npm run check:drift"
+    ]
   }
 }
 ```

--- a/docs/template-trust-contract.md
+++ b/docs/template-trust-contract.md
@@ -1,0 +1,78 @@
+# FFC site profile / template trust contract
+
+Wave 1A adds a small machine-readable profile that generated nonprofit sites and ffcadmin can consume without scraping page content.
+
+## Endpoint
+
+Every generated site should expose:
+
+- `GET /site-profile.json`
+
+The checked-in static file `public/site-profile.json` is copied to the static export at that path. `src/lib/site.config.ts` also exports the typed `siteTrustProfile` / `getSiteTrustProfile()` helpers so application code and tests can verify the public JSON contract against the site's metadata source of truth.
+
+## Schema version
+
+Current version: `ffc.site-profile.v1`
+
+Consumers should treat `schemaVersion` as the compatibility key. Additive fields may be introduced under the same version; breaking changes should use a new version string.
+
+## Contract fields
+
+- `schemaVersion`: profile contract version.
+- `siteId`: stable machine ID for this generated site.
+- `siteName`: display name for dashboards and audit logs.
+- `canonicalUrl`: production origin with no trailing slash.
+- `organization`: nonprofit identity fields safe to publish (`name`, `legalName`, `ein`, `nonprofitStatus`, `country`).
+- `template`: source template family, repository, branch, and issue used for parity tracking.
+- `contacts`: public contact emails and the vulnerability disclosure path.
+- `profileEndpoints`: stable public endpoints ffcadmin can check (`/site-profile.json`, `/.well-known/security.txt`, `/sitemap.xml`, `/robots.txt`).
+- `trust`: declarative trust posture for generated sites. This intentionally includes no credentials, settings secrets, DNS writes, or production controls.
+
+## Example
+
+```json
+{
+  "schemaVersion": "ffc.site-profile.v1",
+  "siteId": "ffc-working-site-1",
+  "siteName": "Free For Charity",
+  "canonicalUrl": "https://ffcworkingsite1.org",
+  "organization": {
+    "name": "Free For Charity",
+    "legalName": "Free For Charity",
+    "ein": "46-2471893",
+    "nonprofitStatus": "us-501c3",
+    "country": "US"
+  },
+  "template": {
+    "family": "ffc-single-page-template",
+    "repository": "FreeForCharity/FFC-IN-FFC_Single_Page_Template",
+    "branch": "agent/sammy/195-site-profile-contract",
+    "issue": "https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/issues/195"
+  },
+  "contacts": {
+    "primaryEmail": "security@freeforcharity.org",
+    "securityEmail": "security@freeforcharity.org",
+    "vulnerabilityDisclosurePath": "/vulnerability-disclosure-policy"
+  },
+  "profileEndpoints": {
+    "siteProfile": "/site-profile.json",
+    "securityTxt": "/.well-known/security.txt",
+    "sitemap": "/sitemap.xml",
+    "robots": "/robots.txt"
+  },
+  "trust": {
+    "generatedBy": "Free For Charity template factory",
+    "hosting": "github-pages-static-export",
+    "requiresHttps": true,
+    "managesSecrets": false,
+    "productionDnsManagedHere": false,
+    "requiredChecks": ["npm run lint", "npm test", "npm run build"]
+  }
+}
+```
+
+## Customizing a generated site
+
+When cloning this template for another nonprofit, update `siteConfig` and `siteTrustProfile` in `src/lib/site.config.ts`, then mirror the same public data in `public/site-profile.json`. The Jest contract test fails if the static JSON drifts from the typed profile. Keep `profileEndpoints` stable unless the route structure changes across the whole fleet.
+
+The contract must remain public-data-only. Do not add API keys, GitHub tokens, DNS provider settings, private admin URLs, or deployment secrets.

--- a/public/site-profile.json
+++ b/public/site-profile.json
@@ -13,7 +13,7 @@
   "template": {
     "family": "ffc-single-page-template",
     "repository": "FreeForCharity/FFC-IN-FFC_Single_Page_Template",
-    "branch": "agent/sammy/195-site-profile-contract",
+    "branch": "main",
     "issue": "https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/issues/195"
   },
   "contacts": {
@@ -33,6 +33,13 @@
     "requiresHttps": true,
     "managesSecrets": false,
     "productionDnsManagedHere": false,
-    "requiredChecks": ["npm run lint", "npm test", "npm run build"]
+    "requiredChecks": [
+      "npm run format:check",
+      "npm run lint",
+      "npm test",
+      "npm run build",
+      "npm run test:e2e",
+      "npm run check:drift"
+    ]
   }
 }

--- a/public/site-profile.json
+++ b/public/site-profile.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "ffc.site-profile.v1",
+  "siteId": "ffc-working-site-1",
+  "siteName": "Free For Charity",
+  "canonicalUrl": "https://ffcworkingsite1.org",
+  "organization": {
+    "name": "Free For Charity",
+    "legalName": "Free For Charity",
+    "ein": "46-2471893",
+    "nonprofitStatus": "us-501c3",
+    "country": "US"
+  },
+  "template": {
+    "family": "ffc-single-page-template",
+    "repository": "FreeForCharity/FFC-IN-FFC_Single_Page_Template",
+    "branch": "agent/sammy/195-site-profile-contract",
+    "issue": "https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/issues/195"
+  },
+  "contacts": {
+    "primaryEmail": "security@freeforcharity.org",
+    "securityEmail": "security@freeforcharity.org",
+    "vulnerabilityDisclosurePath": "/vulnerability-disclosure-policy"
+  },
+  "profileEndpoints": {
+    "siteProfile": "/site-profile.json",
+    "securityTxt": "/.well-known/security.txt",
+    "sitemap": "/sitemap.xml",
+    "robots": "/robots.txt"
+  },
+  "trust": {
+    "generatedBy": "Free For Charity template factory",
+    "hosting": "github-pages-static-export",
+    "requiresHttps": true,
+    "managesSecrets": false,
+    "productionDnsManagedHere": false,
+    "requiredChecks": ["npm run lint", "npm test", "npm run build"]
+  }
+}

--- a/src/lib/site.config.ts
+++ b/src/lib/site.config.ts
@@ -135,11 +135,15 @@ export const siteConfig: SiteConfig = {
   ],
 }
 
+function normalizedSiteOrigin(): string {
+  return siteConfig.url.replace(/\/$/, '')
+}
+
 export const siteTrustProfile: SiteTrustProfile = {
   schemaVersion: 'ffc.site-profile.v1',
   siteId: 'ffc-working-site-1',
   siteName: siteConfig.name,
-  canonicalUrl: siteConfig.url,
+  canonicalUrl: normalizedSiteOrigin(),
   organization: {
     name: siteConfig.name,
     legalName: 'Free For Charity',
@@ -150,7 +154,7 @@ export const siteTrustProfile: SiteTrustProfile = {
   template: {
     family: 'ffc-single-page-template',
     repository: 'FreeForCharity/FFC-IN-FFC_Single_Page_Template',
-    branch: 'agent/sammy/195-site-profile-contract',
+    branch: 'main',
     issue: 'https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/issues/195',
   },
   contacts: {
@@ -170,7 +174,14 @@ export const siteTrustProfile: SiteTrustProfile = {
     requiresHttps: true,
     managesSecrets: false,
     productionDnsManagedHere: false,
-    requiredChecks: ['npm run lint', 'npm test', 'npm run build'],
+    requiredChecks: [
+      'npm run format:check',
+      'npm run lint',
+      'npm test',
+      'npm run build',
+      'npm run test:e2e',
+      'npm run check:drift',
+    ],
   },
 }
 
@@ -179,7 +190,7 @@ export function getSiteTrustProfile(): SiteTrustProfile {
   return {
     ...siteTrustProfile,
     siteName: siteConfig.name,
-    canonicalUrl: siteConfig.url,
+    canonicalUrl: normalizedSiteOrigin(),
     organization: {
       ...siteTrustProfile.organization,
       name: siteConfig.name,
@@ -206,7 +217,7 @@ export function siteUrl(path = '/'): string {
       `siteUrl: path must be a same-origin absolute path starting with a single "/" (got: ${JSON.stringify(path)})`
     )
   }
-  const base = siteConfig.url.replace(/\/$/, '')
+  const base = normalizedSiteOrigin()
   return `${base}${path}`
 }
 

--- a/src/lib/site.config.ts
+++ b/src/lib/site.config.ts
@@ -16,6 +16,54 @@ export type SiteSocialLink = {
   href: string
 }
 
+export type SiteTrustProfile = {
+  /** Contract version for ffcadmin / generated-site automation. */
+  schemaVersion: 'ffc.site-profile.v1'
+  /** Stable machine ID for this generated site. */
+  siteId: string
+  /** Human-readable name for dashboards and audit logs. */
+  siteName: string
+  /** Canonical public origin with no trailing slash. */
+  canonicalUrl: string
+  /** Owning nonprofit or template organization. */
+  organization: {
+    name: string
+    legalName: string
+    ein: string
+    nonprofitStatus: 'us-501c3' | 'unknown' | 'not-applicable'
+    country: string
+  }
+  /** Source template identity used to compare generated sites for parity. */
+  template: {
+    family: 'ffc-single-page-template'
+    repository: string
+    branch: string
+    issue: string
+  }
+  /** Public, non-secret contact channels that automation may display or verify. */
+  contacts: {
+    primaryEmail: string
+    securityEmail: string
+    vulnerabilityDisclosurePath: string
+  }
+  /** Public profile endpoints that generated sites should expose consistently. */
+  profileEndpoints: {
+    siteProfile: '/site-profile.json'
+    securityTxt: '/.well-known/security.txt'
+    sitemap: '/sitemap.xml'
+    robots: '/robots.txt'
+  }
+  /** Expected platform controls; declarative only, not credentials or settings. */
+  trust: {
+    generatedBy: 'Free For Charity template factory'
+    hosting: 'github-pages-static-export'
+    requiresHttps: boolean
+    managesSecrets: false
+    productionDnsManagedHere: false
+    requiredChecks: readonly string[]
+  }
+}
+
 export type SiteConfig = {
   /** Display name of the charity (used in titles, OG/Twitter cards). */
   name: string
@@ -85,6 +133,64 @@ export const siteConfig: SiteConfig = {
     { label: 'LinkedIn', href: 'https://www.linkedin.com/company/freeforcharity/' },
     { label: 'GitHub', href: 'https://github.com/FreeForCharity/FFC_Single_Page_Template' },
   ],
+}
+
+export const siteTrustProfile: SiteTrustProfile = {
+  schemaVersion: 'ffc.site-profile.v1',
+  siteId: 'ffc-working-site-1',
+  siteName: siteConfig.name,
+  canonicalUrl: siteConfig.url,
+  organization: {
+    name: siteConfig.name,
+    legalName: 'Free For Charity',
+    ein: '46-2471893',
+    nonprofitStatus: 'us-501c3',
+    country: 'US',
+  },
+  template: {
+    family: 'ffc-single-page-template',
+    repository: 'FreeForCharity/FFC-IN-FFC_Single_Page_Template',
+    branch: 'agent/sammy/195-site-profile-contract',
+    issue: 'https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/issues/195',
+  },
+  contacts: {
+    primaryEmail: siteConfig.contactEmail,
+    securityEmail: siteConfig.contactEmail,
+    vulnerabilityDisclosurePath: siteConfig.vulnerabilityDisclosurePath,
+  },
+  profileEndpoints: {
+    siteProfile: '/site-profile.json',
+    securityTxt: '/.well-known/security.txt',
+    sitemap: '/sitemap.xml',
+    robots: '/robots.txt',
+  },
+  trust: {
+    generatedBy: 'Free For Charity template factory',
+    hosting: 'github-pages-static-export',
+    requiresHttps: true,
+    managesSecrets: false,
+    productionDnsManagedHere: false,
+    requiredChecks: ['npm run lint', 'npm test', 'npm run build'],
+  },
+}
+
+/** Returns a JSON-serializable profile contract for ffcadmin and generated-site tooling. */
+export function getSiteTrustProfile(): SiteTrustProfile {
+  return {
+    ...siteTrustProfile,
+    siteName: siteConfig.name,
+    canonicalUrl: siteConfig.url,
+    organization: {
+      ...siteTrustProfile.organization,
+      name: siteConfig.name,
+    },
+    contacts: {
+      ...siteTrustProfile.contacts,
+      primaryEmail: siteConfig.contactEmail,
+      securityEmail: siteConfig.contactEmail,
+      vulnerabilityDisclosurePath: siteConfig.vulnerabilityDisclosurePath,
+    },
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a typed `ffc.site-profile.v1` trust/site profile contract in `src/lib/site.config.ts`.
- Publishes a static `public/site-profile.json` endpoint for generated sites/admin tooling.
- Documents the public contract and adds tests tying the typed config to the exported JSON.

## Issue
Closes #195

## Files touched
- `src/lib/site.config.ts` — machine-readable site/trust profile contract.
- `public/site-profile.json` — static exported profile for tooling.
- `docs/template-trust-contract.md` — contract documentation for generated sites and ffcadmin.
- `__tests__/lib/site.config.test.ts` — profile shape/sync/serialization coverage.

## Validation
```bash
npm run format:check
# passed
npm run lint
# passed with 6 existing <img> warnings, 0 errors
npm test -- --runInBand
# 23 suites passed, 102 tests passed
npm run build
# passed; /manifest.webmanifest and /site-profile.json exported
npm run check:drift
# passed: no drift detected
git diff --check
# passed
```

## Risk / rollback
- Risk: low; adds public metadata/docs/tests without changing production copy/layout.
- Rollback: revert this PR; no direct main changes were made.

## Handoff notes for FFC maintainer
- Draft PR for review; agents should not merge this PR.
- This establishes the template contract ffcadmin/generated-site checks can consume later.
