### PR TITLE
docs: update references to removed scaffolding components

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -112,7 +112,7 @@ The FFC Single Page Template was created as a standardized, reusable foundation 
 
 **Current Stats**:
 
-- 112 component files
+- 23 component files
 - Well-organized in `/src/components/`
 - Each component has single responsibility
 

--- a/MICROSOFT_FORM_SETUP.md
+++ b/MICROSOFT_FORM_SETUP.md
@@ -51,14 +51,6 @@ The following components now use the new `ApplicationFormButton`:
    - File: `src/components/home-page/Our-Programs/index.tsx`
    - Location: After the program descriptions, in the "Ready to Get Started Now?" section
 
-2. **Help for Charities - Ready to Get Started**
-   - File: `src/components/help-for-charities/Ready-to-Get-Started-Now/index.tsx`
-   - Used in 501c3 pages
-
-3. **Free Charity Web Hosting - Ready to Get Started**
-   - File: `src/components/free-charity-web-hosting/ReadyToGetStarted/index.tsx`
-   - Used in hosting pages
-
 ## Features
 
 - **Modal Popup**: Opens in a centered modal overlay

--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ Vercel automatically enables PR preview deployments and comments.
 ## Key Features
 
 - **Single-Page Architecture:** One main scrollable page with multiple sections plus 7 policy pages
-- **Component Library:** 112 component files organized by feature/section
+- **Component Library:** 23 component files organized by feature/section
 - **Responsive Navigation:** Mobile and desktop navigation with Header/Footer components
 - **Cookie Consent System:** GDPR-compliant cookie consent management
 - **SEO Optimization:**
@@ -783,32 +783,14 @@ src/
 │   ├── vulnerability-disclosure-policy/       # Vulnerability Disclosure Policy page
 │   ├── sitemap.ts                             # Dynamic sitemap generation
 │   └── robots.ts                              # Robots.txt configuration
-├── components/                                # Reusable components (112 component files)
-│   ├── header/                               # Site header/navigation
-│   ├── footer/                               # Site footer
+├── components/                                # Reusable components
+│   ├── header/                                # Site header/navigation
+│   ├── footer/                                # Site footer
 │   ├── cookie-consent/                        # Cookie consent banner
 │   ├── google-tag-manager/                    # Analytics integration
+│   ├── seo/                                   # SEO / structured data (JSON-LD)
 │   ├── ui/                                    # Reusable UI components
-│   ├── home-page/                             # Homepage-specific components
-│   ├── home/                                  # Alternative home components
-│   ├── domains/                               # Domain-related components
-│   ├── donate/                                # Donation components
-│   ├── volunteer/                             # Volunteer components
-│   ├── 501c3/                                 # 501c3 charity components
-│   ├── about-us/                              # About page components
-│   ├── charity-validation-guide/              # Charity validation guide components
-│   ├── contact-us/                            # Contact form components
-│   ├── endowment-fund/                        # Endowment fund components
-│   ├── free-charity-web-hosting/              # Web hosting program components
-│   ├── guidestar-guide/                       # GuideStar guide components
-│   ├── help-for-charities/                    # Help resources
-│   ├── online-impacts-onboarding/             # Online impacts onboarding components
-│   ├── pre501c3/                              # Pre-501c3 charity components
-│   ├── service-delivery-stages/               # Service delivery stages components
-│   ├── techstack/                             # Technology stack components
-│   ├── tools-for-success/                     # Tools and resources
-│   ├── volunteer-proving-ground/              # Volunteer proving ground components
-│   └── web-developer-training-guide/          # Web developer training guide components
+│   └── home-page/                             # Homepage section components
 ├── data/                                      # Static content
 │   ├── faqs/                                  # FAQ JSON files
 │   ├── team/                                  # Team member data

--- a/SITE_IMPROVEMENTS.md
+++ b/SITE_IMPROVEMENTS.md
@@ -57,7 +57,7 @@ This analysis compares FFC_Single_Page_Template against three sister repositorie
 
 ### Key Findings
 
-**FFC_Single_Page_Template** is a feature-rich, single-page Next.js application with 112 component files and extensive content sections, plus 7 policy pages.
+**FFC_Single_Page_Template** is a single-page Next.js application with 23 component files (after removing unused scaffolding) covering the homepage sections, plus 7 policy pages.
 
 **Note:** As of Phase 5 completion, most critical gaps have been addressed. The items listed below were the original gaps identified, many of which have now been implemented. However, compared to sister sites, some differences remain:
 
@@ -1028,7 +1028,7 @@ module.exports = {
 
 #### Implementation Notes
 
-- Significant CSS work required (all 83 components)
+- Significant CSS work required (all 23 components)
 - Should use Tailwind dark mode utilities
 - Test thoroughly for contrast and readability
 - Consider progressive rollout (opt-in first)

--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -104,7 +104,7 @@ The project has **1 React Hooks ESLint warning** remaining after recent refactor
 
 ---
 
-### Category 4: `@next/next/no-img-element` (6 occurrences)
+### Category 4: `@next/next/no-img-element` (2 occurrences)
 
 **Issue:** Using `<img>` tags instead of Next.js `<Image />` component.
 
@@ -112,10 +112,6 @@ The project has **1 React Hooks ESLint warning** remaining after recent refactor
 
 - `src/components/header/index.tsx`
 - `src/components/footer/index.tsx`
-- `src/components/endowment-fund/Hero/index.tsx`
-- `src/components/free-charity-web-hosting/About-FFC-Hosting/index.tsx`
-- `src/components/ui/General-Donation-Card.tsx`
-- `src/components/ui/trainingcard.tsx`
 
 **Why it's acceptable:**
 

--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -648,7 +648,6 @@ grep -r "ffcworkingsite1.org" . --exclude-dir=node_modules --exclude-dir=.git
 Files to update:
 
 - `src/components/footer/index.tsx` - Footer contact info
-- `src/components/contact-us/` - Contact section
 - `SECURITY.md` - Security contact
 - `CODE_OF_CONDUCT.md` - Conduct reporting contact
 - `SUPPORT.md` - Support contact


### PR DESCRIPTION
Follow-up to #347 (removed 87 unused components). Brings the docs in line with the post-cleanup codebase (23 component files; single home page + 7 policy pages).

## Changes

| Doc | Fix |
|-----|-----|
| **README.md** | Rewrote the `src/components` tree to the **7 dirs that actually exist** (it listed `home/` (never existed) + **18 removed feature dirs**, and omitted `seo/`). Corrected "112 component files" → **23**. |
| **SITE_IMPROVEMENTS.md** | Corrected the Key-Findings count (112 → 23) and the implementation-note count (83 → 23). |
| **LESSONS_LEARNED.md** | "Current Stats" count 112 → 23. |
| **TECHNICAL_DEBT.md** | Category 4 (`no-img-element`) now lists the **2 real occurrences** (header, footer) — the other 4 files were removed. Matches current lint output. |
| **MICROSOFT_FORM_SETUP.md** | Dropped the 2 removed components from the `ApplicationFormButton` usage list (`home-page/Our-Programs` remains). |
| **TEMPLATE_USAGE.md** | Dropped the removed `contact-us/` entry (contact info lives in the footer, already listed). |

## Scope / what I deliberately left

- **Historical records** — e.g. TECHNICAL_DEBT's "Fixed in December 2025 / Fixed Files" lists that reference now-deleted files — are point-in-time records and left intact.
- **Pre-existing drift** not caused by the cleanup (e.g. a `src/components/home/` path that never existed, the guide's `og-image.png`) — out of scope for this PR.

Verified: every `src/components/<dir>` path now referenced in docs resolves to a real directory (except the intentional historical/placeholder ones noted above); Prettier clean; `check:drift` clean. Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_