### PR TITLE
fix(ci): link checker validates the site's own absolute URLs against the local build

### DIFF
--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -16,10 +16,35 @@
 import { createServer } from 'node:http'
 import { spawn } from 'node:child_process'
 import { readFile, stat } from 'node:fs/promises'
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join, normalize, extname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ROOT = fileURLToPath(new URL('../out', import.meta.url))
+
+// The site's canonical origin (siteConfig.url). Absolute self-URLs baked into
+// the build — og:image, twitter:image, JSON-LD logo, rel=canonical — point at
+// this PRODUCTION origin. Below we rewrite that origin to the local preview
+// server so the checker validates THIS build's own assets instead of whatever
+// is currently deployed. Without this, any brand-new asset (e.g. a fresh OG
+// image) 404s in the link check until it ships — a false failure.
+function canonicalOrigin() {
+  try {
+    const cfg = readFileSync(
+      fileURLToPath(new URL('../src/lib/site.config.ts', import.meta.url)),
+      'utf8'
+    )
+    const m = cfg.match(/url:\s*['"]([^'"]+)['"]/)
+    return m ? new URL(m[1]).origin : null
+  } catch {
+    return null
+  }
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
 
 const CONTENT_TYPES = {
   '.html': 'text/html; charset=utf-8',
@@ -109,12 +134,23 @@ function shutdown(code) {
 server.listen(0, '127.0.0.1', () => {
   const { port } = server.address()
   const target = `http://127.0.0.1:${port}`
-  const args = [
-    target,
-    '--recurse',
-    '--config',
-    fileURLToPath(new URL('../.linkinatorrc.json', import.meta.url)),
-  ]
+
+  // Extend the committed config with a URL rewrite mapping the site's
+  // canonical origin to this local server. We go through a generated config
+  // file (rather than linkinator's --url-rewrite-* CLI flags, which are broken
+  // by a casing bug in v7.6.1) because the config-file keys are honored.
+  const baseConfig = JSON.parse(
+    readFileSync(fileURLToPath(new URL('../.linkinatorrc.json', import.meta.url)), 'utf8')
+  )
+  const origin = canonicalOrigin()
+  if (origin) {
+    baseConfig.urlRewriteSearch = `^${escapeRegExp(origin)}`
+    baseConfig.urlRewriteReplace = target
+  }
+  const runtimeConfigPath = join(mkdtempSync(join(tmpdir(), 'linkinator-')), 'config.json')
+  writeFileSync(runtimeConfigPath, JSON.stringify(baseConfig))
+
+  const args = [target, '--recurse', '--config', runtimeConfigPath]
   // Spawn linkinator from PATH — npm puts node_modules/.bin on PATH for
   // scripts, so `npm run check-links` resolves it cross-platform. shell:true
   // on Windows lets the `linkinator.cmd` shim resolve.


### PR DESCRIPTION
## Problem

The "Link check" job serves the static export on a local server and crawls it — but absolute **self-URLs** (`og:image`, `twitter:image`, JSON-LD logo, `rel=canonical`, which Next bakes in as `siteConfig.url`-rooted absolute URLs) were validated against the **live production site**, not the build under test.

Consequence: any brand-new asset 404s in the link check until it's deployed. This is exactly what produced the false failure on #350 (the new 1200×630 `og-image.png`): `[404] https://ffcworkingsite1.org/Images/og-image.png` ×15, because the image existed in the build but wasn't on production yet.

## Fix

`scripts/check-links.mjs` now reads `siteConfig.url`, derives its origin, and adds a linkinator **URL rewrite** mapping that origin → the local preview server. The checker validates **this build's** assets instead of whatever is currently deployed.

- Genuinely missing assets still 404 **locally**, so real broken links are still caught.
- Only the site's **own** canonical origin is rewritten — external links (incl. `freeforcharity.org`) are unaffected.
- If the origin can't be read, it's a no-op (graceful).
- Implemented via a generated runtime config file because linkinator 7.6.1's `--url-rewrite-replace` CLI flag is broken by a casing bug (`urlReWriteReplace`); the **config-file** keys `urlRewriteSearch`/`urlRewriteReplace` are honored (confirmed in `node_modules/linkinator/build/src/{config,cli,index}.js`).

## Verification

- Logic checked locally: origin → `https://ffcworkingsite1.org`; rewrite turns `…/Images/og-image.png` into `http://127.0.0.1:PORT/Images/og-image.png`.
- `npm run build` succeeds, `lint` 0 errors, `check:drift` clean, script parses.
- **Full end-to-end runs in CI** — linkinator can't reach a localhost server through this sandbox's HTTP proxy, so the definitive proof is this PR's own "Link check" going **green** (it exercises the new path and resolves `og-image.png` locally). Watching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_