### PR TITLE
fix(a11y): correct logo aspect ratio and enlarge testimonial dot tap targets

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -101,7 +101,11 @@ const Header: React.FC = () => {
                 <img
                   src={assetPath('/Images/logo.webp')}
                   alt="Free For Charity"
-                  className={`transition-all duration-300 ${isScrolled ? 'h-7' : 'h-11'}`}
+                  width={686}
+                  height={234}
+                  className={`w-auto max-w-none object-contain transition-all duration-300 ${
+                    isScrolled ? 'h-7' : 'h-11'
+                  }`}
                 />
               </Link>
             </div>

--- a/src/components/home-page/Testimonials/index.tsx
+++ b/src/components/home-page/Testimonials/index.tsx
@@ -134,6 +134,7 @@ const TestimonialSlider: React.FC = () => {
 
           {/* Left Arrow */}
           <button
+            type="button"
             ref={prevRef}
             disabled={activeIndex === 0}
             className="absolute left-2 md:left-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center text-gray-600 hover:text-gray-800 transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
@@ -144,6 +145,7 @@ const TestimonialSlider: React.FC = () => {
 
           {/* Right Arrow */}
           <button
+            type="button"
             ref={nextRef}
             disabled={activeIndex === testimonials.length - 1}
             className="absolute right-2 md:right-4 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center text-gray-600 hover:text-gray-800 transition-all disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
@@ -158,6 +160,7 @@ const TestimonialSlider: React.FC = () => {
           {testimonials.map((_, i) => (
             <button
               key={i}
+              type="button"
               onClick={() => handleDotClick(i)}
               className="group flex h-6 min-w-[24px] cursor-pointer items-center justify-center"
               aria-label={`Go to testimonial ${i + 1}`}

--- a/src/components/home-page/Testimonials/index.tsx
+++ b/src/components/home-page/Testimonials/index.tsx
@@ -159,11 +159,17 @@ const TestimonialSlider: React.FC = () => {
             <button
               key={i}
               onClick={() => handleDotClick(i)}
-              className={`h-2 rounded-full transition-all cursor-pointer ${
-                activeIndex === i ? 'bg-orange-600 w-8' : 'bg-gray-300 w-2 hover:bg-gray-400'
-              }`}
+              className="group flex h-6 min-w-[24px] cursor-pointer items-center justify-center"
               aria-label={`Go to testimonial ${i + 1}`}
-            />
+            >
+              <span
+                className={`block h-2 rounded-full transition-all ${
+                  activeIndex === i
+                    ? 'w-8 bg-orange-600'
+                    : 'w-2 bg-gray-300 group-hover:bg-gray-400'
+                }`}
+              />
+            </button>
           ))}
         </div>
       </div>


### PR DESCRIPTION
Targeted fixes for two concrete Lighthouse audit failures, found by running Lighthouse locally against the build and reading the actual failing audits (not guessing).

## Fixes (both verified)

**1. `image-aspect-ratio` (Best Practices)** — the header logo was distorted. It sized by height only (`h-7`/`h-11`), so Tailwind's preflight `max-width:100%` let the fixed-width container clamp the width during the scroll transition → squished logo (displayed 2.48 ratio vs natural 2.93). Now width tracks height at the natural 686×234 ratio (`w-auto max-w-none object-contain` + intrinsic `width`/`height` attributes), so it never distorts.

**2. `target-size` (Accessibility)** — the testimonial pagination dots were 8×8px tap targets, well under the 24px minimum (a WCAG 2.5.8 / AA concern). The small visual pill is preserved but wrapped in a ≥24px tap area, keeping the active (`w-8`) and hover states via `group`.

## Verified locally

Ran Lighthouse before/after against `./out`:

| Audit | Before | After |
|-------|--------|-------|
| `image-aspect-ratio` | 0 | **1** |
| `target-size` | 0 | **1** |
| Best Practices (category) | 93% | **96%** |
| Accessibility (category) | 91% | **95%** |

Also: `lint` 0 errors, `check:drift` clean, `npm test` 91/91 pass.

## Deferred (need your input — not in this PR)

- **`heading-order`**: the home page renders **~10 `<h1>`s** (one per section). Fixing properly is a heading-hierarchy refactor (one `<h1>`, sections become `<h2>`/`<h3>`) across ~10 components — worth doing but architectural.
- **`color-contrast`**: white and orange hero text on the gradient — fixing means adjusting **brand colors**, a design decision.
- **`errors-in-console`**: SSL errors from third-party scripts (GTM/Meta Pixel/Clarity) in the headless test env — largely environment-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_