### PR TITLE
fix(a11y): single-h1 heading hierarchy on the home page

### DIFF
--- a/__tests__/components/home-page/Results-2023.test.tsx
+++ b/__tests__/components/home-page/Results-2023.test.tsx
@@ -33,7 +33,7 @@ import Results from '../../../src/components/home-page/Results-2023'
 describe('Results-2023', () => {
   it('renders the section heading', () => {
     render(<Results />)
-    expect(screen.getByRole('heading', { level: 1, name: /Results - 2023/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2, name: /Results - 2023/i })).toBeInTheDocument()
   })
 
   it('mounts under the #results section landmark id', () => {
@@ -43,9 +43,9 @@ describe('Results-2023', () => {
 
   it('renders four stat cards', () => {
     const { container } = render(<Results />)
-    // Each ResultCard wraps a value in <h1>; the section heading is also <h1>,
-    // so the count is 1 (heading) + 4 (cards) = 5.
-    const headings = container.querySelectorAll('h1')
-    expect(headings.length).toBe(5)
+    // The section heading is an <h2>; each ResultCard wraps its value in an
+    // <h3> (one level below the section), so there are 1 <h2> and 4 <h3>s.
+    expect(container.querySelectorAll('h2').length).toBe(1)
+    expect(container.querySelectorAll('h3').length).toBe(4)
   })
 })

--- a/__tests__/components/ui/ResultCard.test.tsx
+++ b/__tests__/components/ui/ResultCard.test.tsx
@@ -42,9 +42,9 @@ describe('ResultCard', () => {
     expect(screen.getByText('Volunteers')).toBeInTheDocument()
   })
 
-  it('renders the title inside an <h1>', () => {
+  it('renders the title inside an <h3>', () => {
     render(<ResultCard title="50" description="Partners" />)
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('50')
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('50')
   })
 
   it('falls back to plain text for titles that mix digits and letters', () => {

--- a/src/components/home-page/Endowment-Features/index.tsx
+++ b/src/components/home-page/Endowment-Features/index.tsx
@@ -7,12 +7,12 @@ const Home: React.FC = () => {
     <div className="pb-[30px]">
       <div className="w-[90%] mx-auto lg:px-[20px] max-w-[1280px]">
         <div>
-          <h1
+          <h2
             className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[30px]"
             id="faustina-font"
           >
             Free For Charity Endowment Features
-          </h1>
+          </h2>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-[24px]">
             <SustainableFundingCard
               imageUrl={assetPath('/Svgs/sustainable-funding.svg')}

--- a/src/components/home-page/Events/index.tsx
+++ b/src/components/home-page/Events/index.tsx
@@ -4,12 +4,12 @@ const Events = () => {
   return (
     <div id="events" className="py-[52px]">
       <div className="w-[90%] mx-auto max-w-[1280px]">
-        <h1
+        <h2
           className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[50px]"
           id="faustina-font"
         >
           Upcoming Events
-        </h1>
+        </h2>
 
         <div className="text-center mb-8">
           <p className="text-[20px] lg:text-[25px] font-[500]" id="lato-font">

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -5,12 +5,12 @@ const index = () => {
   return (
     <div id="faq" className="py-[50px]">
       <div className="w-[90%] mx-auto lg:px-[20px]">
-        <h1
+        <h2
           className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
           id="faustina-font"
         >
           Frequently Asked Questions
-        </h1>
+        </h2>
         <div>
           <FrequentlyAskedQuestions title="What is the organization aiming to accomplish?">
             <p className="mb-[30px]">

--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -5,12 +5,12 @@ const index = () => {
   return (
     <div id="mission" className="py-[52px]">
       <div className="w-[90%] mx-auto py-[27px] mb-[60px] max-w-[1280px]">
-        <h1
+        <h2
           className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center w-full lg:w-[906px] mx-auto mb-[50px]"
           id="faustina-font"
         >
           Free For Charity has a simple mission with broad implications
-        </h1>
+        </h2>
         <p
           className="font-[700] text-[25px] leading-[150%] tracking-[0] text-center mb-[30px]"
           id="lato-font"

--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -8,12 +8,12 @@ const index = () => {
   return (
     <div id="programs" className="py-[52px]">
       <div className="w-[90%] lg:px-[20px] mx-auto">
-        <h1
+        <h2
           className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
           id="faustina-font"
         >
           Our Programs
-        </h1>
+        </h2>
 
         <div className="lg:pl-[50px]">
           <div className="mb-[40px]  flex items-center gap-[20px]">
@@ -27,9 +27,9 @@ const index = () => {
                 ></Image>
               </div>
             </div>
-            <h1 className="text-[36px] font-[400] " id="lato-font">
+            <h3 className="text-[36px] font-[400] " id="lato-font">
               FFC Domains
-            </h1>
+            </h3>
           </div>
           <p className="text-[25px] font-[400] " id="lato-font">
             Provides free .org domain names, Microsoft 365 with Outlook email, & Microsoft Teams to
@@ -88,9 +88,9 @@ const index = () => {
                 ></Image>
               </div>
             </div>
-            <h1 className="text-[36px] font-[400]  " id="lato-font">
+            <h3 className="text-[36px] font-[400]  " id="lato-font">
               FFC Hosting
-            </h1>
+            </h3>
           </div>
           <p className="text-[25px] font-[400]  " id="lato-font">
             Free static site hosting for nonprofit organizations using Microsoft GitHub Pages, with
@@ -159,9 +159,9 @@ const index = () => {
                 ></Image>
               </div>
             </div>
-            <h1 className="text-[36px] font-[400]  " id="lato-font">
+            <h3 className="text-[36px] font-[400]  " id="lato-font">
               FFC Consulting
-            </h1>
+            </h3>
           </div>
           <p className="text-[25px] font-[400]  " id="lato-font">
             FFC Consulting is about helping charities get the most out of their digital
@@ -211,9 +211,9 @@ const index = () => {
         </div>
 
         <div className="lg:w-[90%] mx-auto text-center pb-[54px] pt-[20px]">
-          <h1 className="text-[36px] font-[400] pt-[22px] pb-[30px]" id="lato-font">
+          <h3 className="text-[36px] font-[400] pt-[22px] pb-[30px]" id="lato-font">
             Ready to Get Started Now?
-          </h1>
+          </h3>
 
           <div className="flex items-center justify-center">
             <ApplicationFormButton />

--- a/src/components/home-page/Results-2023/index.tsx
+++ b/src/components/home-page/Results-2023/index.tsx
@@ -5,12 +5,12 @@ const index = () => {
   return (
     <div id="results">
       <div className="w-[90%] mx-auto py-[52px] lg:px-[20px]">
-        <h1
+        <h2
           className="mt-[2px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px]  text-center mb-[40px]"
           id="faustina-font"
         >
           Results - 2023
-        </h1>
+        </h2>
         <div className="pt-[30px] grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-[20px]">
           <ResultCard title="221" description="Organizational partners" />
           <ResultCard title="3" description="Total volunteers" />

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -30,12 +30,12 @@ const Index = () => {
   return (
     <div id="donate">
       <div className="w-[90%] mx-auto py-[27px] mb-[60px] px-[20px] max-w-[1280px]">
-        <h1
+        <h2
           className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[60px]"
           id="faustina-font"
         >
           Support Free For Charity
-        </h1>
+        </h2>
 
         <div className="flex items-center flex-col lg:flex-row gap-[40px] lg:gap-[20px]">
           {/* Left side: Description and pointing hands image */}

--- a/src/components/home-page/TheFreeForCharityTeam/index.tsx
+++ b/src/components/home-page/TheFreeForCharityTeam/index.tsx
@@ -5,12 +5,12 @@ import { assetPath } from '@/lib/assetPath'
 const index = () => {
   return (
     <div id="team" className="py-[50px]">
-      <h1
+      <h2
         className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
         id="faustina-font"
       >
         The Free For Charity Team
-      </h1>
+      </h2>
 
       <div className="w-[90%] mx-auto py-[40px]">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3  items-stretch justify-center mb-[50px] gap-[30px]">

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -6,12 +6,12 @@ const index = () => {
   return (
     <div id="volunteer" className="bg-[#2A6682] py-[40px]">
       <div className="w-[90%] mx-auto lg:px-[20px]">
-        <h1
+        <h2
           className="mt-[2px] mb-[42px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px] text-center text-white"
           id="faustina-font"
         >
           Volunteer with Us
-        </h1>
+        </h2>
         <p
           className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center text-white"
           id="lato-font"

--- a/src/components/ui/ResultCard.tsx
+++ b/src/components/ui/ResultCard.tsx
@@ -13,9 +13,9 @@ const ResultCard: React.FC<ResultCardProps> = ({ title, description }) => {
 
   return (
     <div className="w-full h-[300px] px-[20px] flex items-center justify-center flex-col border-[5px] border-[#F58629] rounded-[20px] shadow-[0px_16px_16px_0px_#11253E0F]">
-      <h1 className="text-[64px] font-[400]" id="faustina-font">
+      <h3 className="text-[64px] font-[400]" id="faustina-font">
         {!isNaN(numericValue) ? <AnimatedNumber value={numericValue} /> : title}
-      </h1>
+      </h3>
       <p className="text-center text-[25px] font-[400]" id="lato-font">
         {description}
       </p>

--- a/tests/animated-numbers.spec.ts
+++ b/tests/animated-numbers.spec.ts
@@ -22,7 +22,7 @@ test.describe('Results 2023 Animated Numbers', () => {
 
     // Find the Results section heading
     const resultsHeading = page.locator(
-      `h1:has-text("${testConfig.animatedNumbers.sectionHeading}")`
+      `h2:has-text("${testConfig.animatedNumbers.sectionHeading}")`
     )
     await expect(resultsHeading).toBeVisible()
 
@@ -31,7 +31,7 @@ test.describe('Results 2023 Animated Numbers', () => {
 
     // Wait for animation to complete by checking final values
     for (const stat of testConfig.animatedNumbers.statistics) {
-      await expect(getResultCard(page, stat.description).locator('h1')).toContainText(stat.value, {
+      await expect(getResultCard(page, stat.description).locator('h3')).toContainText(stat.value, {
         timeout: 5000,
       })
     }
@@ -43,11 +43,11 @@ test.describe('Results 2023 Animated Numbers', () => {
 
     // Verify the numbers start at 0 before scrolling into view
     const firstStat = testConfig.animatedNumbers.statistics[0]
-    const firstCardNumber = getResultCard(page, firstStat.description).locator('h1')
+    const firstCardNumber = getResultCard(page, firstStat.description).locator('h3')
     await expect(firstCardNumber).toContainText('0')
 
     const resultsSection = page.locator(
-      `h1:has-text("${testConfig.animatedNumbers.sectionHeading}")`
+      `h2:has-text("${testConfig.animatedNumbers.sectionHeading}")`
     )
     await expect(resultsSection).toBeAttached()
   })
@@ -58,13 +58,13 @@ test.describe('Results 2023 Animated Numbers', () => {
 
     // Find and scroll to the Results section
     const resultsHeading = page.locator(
-      `h1:has-text("${testConfig.animatedNumbers.sectionHeading}")`
+      `h2:has-text("${testConfig.animatedNumbers.sectionHeading}")`
     )
     await resultsHeading.scrollIntoViewIfNeeded()
 
     // Wait for animation to complete by checking the final value
     const firstStat = testConfig.animatedNumbers.statistics[0]
-    const firstCardNumber = getResultCard(page, firstStat.description).locator('h1')
+    const firstCardNumber = getResultCard(page, firstStat.description).locator('h3')
     await expect(firstCardNumber).toContainText(firstStat.value, { timeout: 5000 })
 
     // Scroll away and back
@@ -94,7 +94,7 @@ test.describe('Results 2023 Animated Numbers', () => {
 
     await page.goto('/')
     const resultsHeading = page.locator(
-      `h1:has-text("${testConfig.animatedNumbers.sectionHeading}")`
+      `h2:has-text("${testConfig.animatedNumbers.sectionHeading}")`
     )
     // Wait for the element to be visible before scrolling
     await expect(resultsHeading).toBeVisible({ timeout: 5000 })
@@ -102,7 +102,7 @@ test.describe('Results 2023 Animated Numbers', () => {
 
     // With reduced motion, numbers should appear instantly at final value
     const firstStat = testConfig.animatedNumbers.statistics[0]
-    const firstCardNumber = getResultCard(page, firstStat.description).locator('h1')
+    const firstCardNumber = getResultCard(page, firstStat.description).locator('h3')
     await expect(firstCardNumber).toContainText(firstStat.value, { timeout: 1000 })
 
     await context.close()

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -24,7 +24,7 @@ test.describe('Events Section', () => {
     await expect(eventsSection).toBeVisible()
 
     // Verify section heading is present
-    const heading = eventsSection.locator('h1')
+    const heading = eventsSection.locator('h2')
     await expect(heading).toBeVisible()
     await expect(heading).toContainText(testConfig.events.heading)
   })
@@ -184,7 +184,7 @@ test.describe('Events Section', () => {
     await expect(eventsIframe).toBeVisible()
 
     // Verify heading is visible on mobile
-    const heading = eventsSection.locator('h1')
+    const heading = eventsSection.locator('h2')
     await expect(heading).toBeVisible()
   })
 })

--- a/tests/reduced-motion.spec.ts
+++ b/tests/reduced-motion.spec.ts
@@ -22,9 +22,9 @@ test.describe('prefers-reduced-motion', () => {
     // Scroll Results-2023 into view so AnimatedNumber's useInView fires.
     await page.locator('#results').scrollIntoViewIfNeeded()
 
-    // Find the four stat-card headings (the first <h1> under #results is
-    // the section title "Results - 2023"; the four numeric ones come next).
-    const statHeadings = page.locator('#results h1').filter({ hasText: /^\d/ })
+    // Find the four stat-card headings (the section title under #results is an <h2>;
+    // the four numeric stat cards are <h3>.
+    const statHeadings = page.locator('#results h3').filter({ hasText: /^\d/ })
     await expect(statHeadings).toHaveCount(4)
 
     // Poll until two consecutive reads match. Under reduced-motion the
@@ -35,7 +35,7 @@ test.describe('prefers-reduced-motion', () => {
     // loop would never converge inside the allotted window.
     const settled = await page.evaluate(async () => {
       const reads = (): string[] =>
-        Array.from(document.querySelectorAll('#results h1'))
+        Array.from(document.querySelectorAll('#results h3'))
           .map((el) => (el.textContent ?? '').trim())
           .filter((t) => /^\d+$/.test(t))
 


### PR DESCRIPTION
First of the two deferred Lighthouse a11y items. Fixes the `heading-order` audit on the home page.

## Problem

The home page rendered **~10 `<h1>`s** — one per section, plus a `<h1>` per `ResultCard` stat figure. That fails Lighthouse's `heading-order` audit and is poor for SEO and screen-reader navigation (no clear document outline).

## Fix — conventional hierarchy

- **Hero** keeps the page's single `<h1>`.
- Every other **section title → `<h2>`** (Mission, Support, Endowment, Our Programs, Volunteer, Results, Team, FAQ, Events; Testimonials was already `<h2>`).
- **Sub-items → `<h3>`** under their section: the Our Programs cards + CTA, and the `ResultCard` stat numbers (`<h2>` Results section → `<h3>` figures).

Tag changes only — all `className`s are preserved, so the visual design is unchanged. Updated the `ResultCard` and `Results-2023` unit tests to assert the new levels.

## Verified (local Lighthouse run)

| | Before | After |
|---|---|---|
| `heading-order` | 0 | **1** |
| Accessibility | 91% | **96%** |
| `<h1>`s on home | ~10 | **1** |

`npm run lint` 0 errors, `check:drift` clean, `npm test` **91/91** pass.

## Note

The **policy pages** (terms-of-service, privacy-policy, etc.) also use many `<h1>`s — a separate, larger heading cleanup if you want it. They currently still pass the a11y threshold (94–96%).

The second deferred item — **`color-contrast`** — is coming as its own PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_