### PR TITLE
fix(a11y): meet WCAG AA color contrast on home page text

### DIFF
--- a/src/components/home-page/Events/index.tsx
+++ b/src/components/home-page/Events/index.tsx
@@ -38,7 +38,7 @@ const Events = () => {
               href="https://www.facebook.com/freeforcharity"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[#2EA3F2] hover:underline"
+              className="text-[#227AB5] hover:underline"
             >
               View all events on Facebook
             </a>

--- a/src/components/home-page/Hero/index.tsx
+++ b/src/components/home-page/Hero/index.tsx
@@ -17,7 +17,7 @@ const CharityHeroBackground = () => {
 
       {/* 3. Orange Bottom-Right Section - Starts exactly where white ends */}
       <div
-        className="absolute inset-0 bg-[#F57C20]"
+        className="absolute inset-0 bg-[#E4731E]"
         style={{
           clipPath: 'polygon(0% 111%, 100% 35%, 100% 100%, 0% 100%)',
         }}

--- a/src/components/home-page/Testimonials/index.tsx
+++ b/src/components/home-page/Testimonials/index.tsx
@@ -70,7 +70,7 @@ const TestimonialSlider: React.FC = () => {
   return (
     <section id="testimonials" className="py-16 pb-25 bg-[#FCFCFC]">
       <div className="container mx-auto px-4 max-w-[1150px] text-center">
-        <h2 className="font-bold text-[#F27022] text-[40px] leading-[44px] mb-7">Testimonials</h2>
+        <h2 className="font-bold text-[#E16820] text-[40px] leading-[44px] mb-7">Testimonials</h2>
 
         <div className="relative">
           <Swiper
@@ -117,7 +117,7 @@ const TestimonialSlider: React.FC = () => {
 
                   {t.location && (
                     <a href="https://americanlegionpost64.org/">
-                      <p className="text-[14px] font-medium text-[#2EA3F2]" id="aria-font">
+                      <p className="text-[14px] font-medium text-[#227AB5]" id="aria-font">
                         {t.location}
                       </p>
                     </a>


### PR DESCRIPTION
The second deferred Lighthouse a11y item. Fixes the `color-contrast` audit (4 failing elements).

## Approach

I computed contrast ratios against the **actual rendered backgrounds** and chose the **minimal, on-brand** darkening that clears AA, so the brand look is preserved. Each change verified with a local Lighthouse run.

| Element | Before | After | Contrast | AA needs |
|---|---|---|---|---|
| Hero heading + subtext (white on orange) | bg `#F57C20` | **`#E4731E`** | 2.69 → **3.1** | 3.0 (large) |
| Testimonials heading (orange on white) | `#F27022` | **`#E16820`** | 2.87 → **3.3** | 3.0 (large) |
| "View all events" FB link + testimonial location (blue on white) | `#2EA3F2` | **`#227AB5`** | 2.74 → **4.65** | 4.5 (normal) |

The Hero/heading oranges are darkened only ~2–7% (barely perceptible); the link blue is a more noticeable deepening (it failed badly at 2.74).

**Deliberately left unchanged:** light-blue `#2EA3F2` on **dark** backgrounds (footer on black, header border) — those already have strong contrast, and darkening them would *reduce* it.

## Verified (local Lighthouse)

- `color-contrast`: 0 → **1**
- Accessibility: → **98%** (and ~100% once combined with the heading-hierarchy PR #353)
- `npm run lint` 0 errors, `check:drift` clean, tests pass

## Note

Opened as a **draft** because these are brand colors — review the exact shades and let me know if you'd prefer different values (e.g. the brand blue `#2E6F8E`, which also passes at 5.55:1, for the links). Easy to swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_