### PR TITLE
fix(a11y): duplicate font-ID classes + policy-page heading-order & contrast

### DIFF
--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -12,7 +12,7 @@ export default function CookiePolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="aria-font">
+        <div className="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">
             <strong>Cookie Policy</strong>
           </h1>

--- a/src/app/free-for-charity-donation-policy/page.tsx
+++ b/src/app/free-for-charity-donation-policy/page.tsx
@@ -10,7 +10,7 @@ const index = () => {
   return (
     <div className="pt-[140px]">
       <div className="py-[21px] w-[90%] md:w-[80%] mx-auto max-w-[1080px]">
-        <div id="aria-font">
+        <div className="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[30px] font-[500]">
             Free For Charity Donation Policy
           </h1>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,10 +44,10 @@ body {
 #header {
   font-family: var(--font-open-sans), sans-serif !important;
 }
-#aria-font {
+.aria-font {
   font-family: var(--font-open-sans), sans-serif !important;
 }
-#lato-font {
+.lato-font {
   font-family: var(--font-lato), sans-serif !important;
 }
 #montserrat-font {
@@ -75,7 +75,7 @@ body {
 #courier-font {
   font-family: ui-monospace, 'Courier New', monospace !important;
 }
-#faustina-font {
+.faustina-font {
   font-family: var(--font-faustina), serif !important;
 }
 

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -9,7 +9,7 @@ export default function PrivacyPolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="aria-font">
+        <div className="aria-font">
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]"></p>
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">
             <strong>Privacy Policy</strong>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -162,7 +162,7 @@ export default function PrivacyPolicy() {
                 href="https://privacy.microsoft.com/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#007bff] underline"
+                className="text-[#0062CC] underline"
               >
                 https://privacy.microsoft.com/
               </a>
@@ -456,7 +456,7 @@ export default function PrivacyPolicy() {
           <ul className="list-inside list-disc space-y-[4px] pb-[1em]">
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
               <strong>Email:</strong>{' '}
-              <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#007bff] underline">
+              <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0062CC] underline">
                 clarkemoyer@freeforcharity.org
               </a>{' '}
               520-222-8104
@@ -482,7 +482,7 @@ export default function PrivacyPolicy() {
           <ul className="list-inside list-disc space-y-[4px] pb-[1em]">
             <li className="text-[14px] text-[#666] leading-[24px] font-[500]">
               <strong>Contact DPO:</strong> Clarke Moyer{' '}
-              <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#007bff] underline">
+              <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0062CC] underline">
                 clarkemoyer@freeforcharity.org
               </a>{' '}
               520-222-8104

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -11,7 +11,7 @@ const index = () => {
   return (
     <div className="pt-[130px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div className="border-t-[5px] border-[#0073e6] pt-[25px]" id="lato-font">
+        <div className="border-t-[5px] border-[#0073e6] pt-[25px] lato-font">
           <h2 className="text-[30px] leading-[30px] font-[700] text-[#333] mt-[20px] mb-[25px]">
             Security Acknowledgements
           </h2>
@@ -21,10 +21,7 @@ const index = () => {
             responsibly disclosing vulnerabilities, they have played a crucial role in protecting
             our users and our data.
           </p>
-          <div
-            className="bg-[#f9f9f9] border-l-[5px] border-[#cccccc] p-[20px] mt-[30px] mb-[30px]"
-            id="lato-font"
-          >
+          <div className="bg-[#f9f9f9] border-l-[5px] border-[#cccccc] p-[20px] mt-[30px] mb-[30px] lato-font">
             <p className="mb-[10px]  text-[14px] font-[500] leading-[25px] text-[#666]">
               As of now, we have not received any vulnerability reports that qualify for public
               acknowledgment. This page will be updated to credit researchers as reports are

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -236,7 +236,7 @@ export default function TermsOfService() {
           </p>
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
             Email:{' '}
-            <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#007bff] underline">
+            <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0062CC] underline">
               clarkemoyer@freeforcharity.org
             </a>
           </p>

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -9,7 +9,7 @@ export default function TermsOfService() {
   return (
     <div className="pt-[130px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="aria-font">
+        <div className="aria-font">
           {/* Effective Date */}
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]">
             <em>Effective Date: 11-20-2024</em>

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -9,7 +9,7 @@ export default function VulnerabilityDisclosurePolicy() {
   return (
     <div className="pt-[130px] pb-[54px]">
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
-        <div id="lato-font">
+        <div className="lato-font">
           {/* Main Title */}
           <h2 className="text-[26px] font-bold text-[#333] mt-[40px] mb-[20px]">
             Vulnerability Disclosure Policy for Free For Charity

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -52,20 +52,20 @@ export default function VulnerabilityDisclosurePolicy() {
           </p>
           <ul className="list-disc pl-[40px] pb-[23px] leading-[26px] mb-[20px] space-y-[10px] text-[14px]">
             <li>
-              <a href="https://freeforcharity.org" className="text-[#007bff] underline">
+              <a href="https://freeforcharity.org" className="text-[#0062CC] underline">
                 freeforcharity.org
               </a>{' '}
               (WordPress)
             </li>
             <li>
-              <a href="https://freeforcharity.org/hub" className="text-[#007bff] underline">
+              <a href="https://freeforcharity.org/hub" className="text-[#0062CC] underline">
                 freeforcharity.org/hub
               </a>{' '}
               (WHMCS)
             </li>
             <li>
               Any other publicly accessible services hosted under{' '}
-              <a href="https://freeforcharity.org" className="text-[#007bff] underline">
+              <a href="https://freeforcharity.org" className="text-[#0062CC] underline">
                 freeforcharity.org
               </a>
             </li>
@@ -99,13 +99,13 @@ export default function VulnerabilityDisclosurePolicy() {
           <ul className="list-disc pl-[40px] pb-[23px] leading-[26px] mb-[20px]  space-y-[10px] text-[14px]">
             <li>
               <strong>Email:</strong>{' '}
-              <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#007bff] underline">
+              <a href="mailto:clarkemoyer@freeforcharity.org" className="text-[#0062CC] underline">
                 clarkemoyer@freeforcharity.org
               </a>
             </li>
             <li>
               <strong>Text:</strong>{' '}
-              <a href="sms:15202228104" className="text-[#007bff] underline">
+              <a href="sms:15202228104" className="text-[#0062CC] underline">
                 1 520 222 8104
               </a>
             </li>
@@ -193,7 +193,7 @@ export default function VulnerabilityDisclosurePolicy() {
             offer a public acknowledgment on our{' '}
             <a
               href="https://freeforcharity.org/security-acknowledgements"
-              className="text-[#007bff] underline"
+              className="text-[#0062CC] underline"
             >
               Security Acknowledgements
             </a>{' '}

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -49,8 +49,7 @@ const Footer: React.FC = () => {
               href="https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742"
               className="group relative my-4 flex w-full max-w-[230px] items-center justify-between
                 border-2 border-[#2ea3f2] bg-black px-5 py-2.5 text-[#2ea3f2]
-                transition-all duration-300 hover:border-transparent"
-              id="aria-font"
+                transition-all duration-300 hover:border-transparent aria-font"
             >
               <span className="text-[17px] font-medium leading-tight sm:text-[18px] md:text-[20px] transition-transform duration-300 group-hover:-translate-x-1">
                 Direct GuideStar Profile Link
@@ -72,7 +71,7 @@ const Footer: React.FC = () => {
         <div className="space-y-6 px-4 sm:px-0">
           <h3 className="text-[28px] text-white">Quick Links</h3>
 
-          <ul className="space-y-2 text-sm" id="lato-font">
+          <ul className="space-y-2 text-sm lato-font">
             {[
               { name: 'Home', href: '/#hero' },
               { name: 'Mission', href: '/#mission' },
@@ -101,7 +100,7 @@ const Footer: React.FC = () => {
 
           <div className="space-y-3">
             <h4 className="text-[28px] text-white">Free For Charity Policy</h4>
-            <ul className="space-y-1 text-sm" id="lato-font">
+            <ul className="space-y-1 text-sm lato-font">
               {[
                 {
                   name: 'Free For Charity Donation Policy',
@@ -156,8 +155,7 @@ const Footer: React.FC = () => {
                 <p className="font-[500] text-[22px]">E-mail</p>
                 <a
                   href={`mailto:${siteConfig.contactEmail}`}
-                  className="font-[500] text-[15px] hover:text-cyan-400 transition-colors break-all"
-                  id="aria-font"
+                  className="font-[500] text-[15px] hover:text-cyan-400 transition-colors break-all aria-font"
                 >
                   {siteConfig.contactEmail}
                 </a>
@@ -170,8 +168,7 @@ const Footer: React.FC = () => {
                 <p className="font-[500] text-[22px]">Call Us Today</p>
                 <a
                   href="tel:5202228104"
-                  className="font-[500] text-[16px] hover:text-cyan-400 transition-colors"
-                  id="aria-font"
+                  className="font-[500] text-[16px] hover:text-cyan-400 transition-colors aria-font"
                 >
                   (520) 222-8104
                 </a>
@@ -188,7 +185,7 @@ const Footer: React.FC = () => {
               <MapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">Main Address</p>
-                <p className="font-[500] text-[16px]" id="aria-font">
+                <p className="font-[500] text-[16px] aria-font">
                   4030 Wake Forrest Road
                   <br />
                   Suite 349 Raleigh North
@@ -208,7 +205,7 @@ const Footer: React.FC = () => {
               <MapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">PA Office Address</p>
-                <p className="font-[500] text-[16px]" id="aria-font">
+                <p className="font-[500] text-[16px] aria-font">
                   301 Science Park Road Suite
                   <br />
                   119 State College PA 16803
@@ -238,10 +235,7 @@ const Footer: React.FC = () => {
       </div>
 
       {/* Bottom Bar */}
-      <div
-        className="mt-12 py-6 px-4 border-t border-gray-800 text-center text-[18px] font-[500] w-full"
-        id="aria-font"
-      >
+      <div className="mt-12 py-6 px-4 border-t border-gray-800 text-center text-[18px] font-[500] w-full aria-font">
         <p>
           © {currentYear} All Rights Are Reserved by {siteConfig.name} a US 501c3 Non Profit | A
           project of{' '}

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -33,7 +33,7 @@ const Footer: React.FC = () => {
       <div className="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5 py-12 px-4 md:px-6 lg:px-8">
         {/* Column 1: Endorsements */}
         <div className="space-y-6 px-4 sm:px-0">
-          <h3 className="text-[28px] text-white">Endorsements</h3>
+          <h2 className="text-[28px] text-white">Endorsements</h2>
 
           <div className="space-y-4">
             <a
@@ -69,7 +69,7 @@ const Footer: React.FC = () => {
 
         {/* Column 2: Quick Links */}
         <div className="space-y-6 px-4 sm:px-0">
-          <h3 className="text-[28px] text-white">Quick Links</h3>
+          <h2 className="text-[28px] text-white">Quick Links</h2>
 
           <ul className="space-y-2 text-sm lato-font">
             {[
@@ -99,7 +99,7 @@ const Footer: React.FC = () => {
           </ul>
 
           <div className="space-y-3">
-            <h4 className="text-[28px] text-white">Free For Charity Policy</h4>
+            <h3 className="text-[28px] text-white">Free For Charity Policy</h3>
             <ul className="space-y-1 text-sm lato-font">
               {[
                 {
@@ -146,7 +146,7 @@ const Footer: React.FC = () => {
 
         {/* Column 3: Contact Us */}
         <div className="space-y-6 px-4 sm:px-0">
-          <h3 className="text-[28px] text-white">Contact Us</h3>
+          <h2 className="text-[28px] text-white">Contact Us</h2>
 
           <div className="space-y-4 text-sm">
             <div className="flex items-start gap-3">

--- a/src/components/home-page/Endowment-Features/index.tsx
+++ b/src/components/home-page/Endowment-Features/index.tsx
@@ -7,10 +7,7 @@ const Home: React.FC = () => {
     <div className="pb-[30px]">
       <div className="w-[90%] mx-auto lg:px-[20px] max-w-[1280px]">
         <div>
-          <h2
-            className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[30px]"
-            id="faustina-font"
-          >
+          <h2 className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[30px] faustina-font">
             Free For Charity Endowment Features
           </h2>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-[24px]">

--- a/src/components/home-page/Events/index.tsx
+++ b/src/components/home-page/Events/index.tsx
@@ -4,15 +4,12 @@ const Events = () => {
   return (
     <div id="events" className="py-[52px]">
       <div className="w-[90%] mx-auto max-w-[1280px]">
-        <h2
-          className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[50px]"
-          id="faustina-font"
-        >
+        <h2 className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[50px] faustina-font">
           Upcoming Events
         </h2>
 
         <div className="text-center mb-8">
-          <p className="text-[20px] lg:text-[25px] font-[500]" id="lato-font">
+          <p className="text-[20px] lg:text-[25px] font-[500] lato-font">
             Join us for upcoming volunteer opportunities, training sessions, and community events.
           </p>
         </div>
@@ -33,7 +30,7 @@ const Events = () => {
         </div>
 
         <div className="text-center mt-8">
-          <p className="text-[18px] font-[400] text-gray-600" id="lato-font">
+          <p className="text-[18px] font-[400] text-gray-600 lato-font">
             <a
               href="https://www.facebook.com/freeforcharity"
               target="_blank"

--- a/src/components/home-page/FrequentlyAskedQuestions/index.tsx
+++ b/src/components/home-page/FrequentlyAskedQuestions/index.tsx
@@ -5,10 +5,7 @@ const index = () => {
   return (
     <div id="faq" className="py-[50px]">
       <div className="w-[90%] mx-auto lg:px-[20px]">
-        <h2
-          className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
-          id="faustina-font"
-        >
+        <h2 className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px] faustina-font">
           Frequently Asked Questions
         </h2>
         <div>

--- a/src/components/home-page/Hero/index.tsx
+++ b/src/components/home-page/Hero/index.tsx
@@ -25,37 +25,28 @@ const CharityHeroBackground = () => {
 
       <div className="hero-container flex flex-col lg:flex-row gap-[40px] lg:gap-[0px] items-center justify-between relative z-10 text-white pt-[130px] w-[90%] mx-auto max-w-[1280px] lg:px-[20px]">
         <div className="w-full lg:w-[565px]">
-          <h1
-            className="text-[50px] lg:text-[60px] font-[500] text-[#FFFFFF] leading-[120%] mb-[20px]"
-            id="faustina-font"
-          >
+          <h1 className="text-[50px] lg:text-[60px] font-[500] text-[#FFFFFF] leading-[120%] mb-[20px] faustina-font">
             Welcome to <br /> Free For Charity
           </h1>
-          <p
-            className="text-[24px] font-[400] leading-[120%] text-[#FFFFFF] mb-[20px]"
-            id="lato-font"
-          >
+          <p className="text-[24px] font-[400] leading-[120%] text-[#FFFFFF] mb-[20px] lato-font">
             Connecting Students, Professionals, & Businesses with Charities in Need
           </p>
           <a
             href="#volunteer"
-            className="top-[378px] w-[300px] lg:w-[351px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] mb-[10px] whitespace-nowrap"
-            id="lato-font"
+            className="top-[378px] w-[300px] lg:w-[351px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] mb-[10px] whitespace-nowrap lato-font"
           >
             Volunteer
           </a>
           <div className="flex gap-[5px]">
             <a
               href="#donate"
-              className="top-[442px] w-[130px] lg:w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
-              id="lato-font"
+              className="top-[442px] w-[130px] lg:w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap lato-font"
             >
               Donate
             </a>
             <a
               href="#programs"
-              className="top-[442px] w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap"
-              id="lato-font"
+              className="top-[442px] w-[173px] h-[54px] opacity-100 rounded-[27px] px-[32px] py-[18px] flex items-center justify-center gap-[10px] bg-[#FFFFFF] text-[#113563] text-[20px] font-[400] leading-[100%] whitespace-nowrap lato-font"
             >
               Our Programs
             </a>

--- a/src/components/home-page/Mission/index.tsx
+++ b/src/components/home-page/Mission/index.tsx
@@ -5,23 +5,14 @@ const index = () => {
   return (
     <div id="mission" className="py-[52px]">
       <div className="w-[90%] mx-auto py-[27px] mb-[60px] max-w-[1280px]">
-        <h2
-          className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center w-full lg:w-[906px] mx-auto mb-[50px]"
-          id="faustina-font"
-        >
+        <h2 className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center w-full lg:w-[906px] mx-auto mb-[50px] faustina-font">
           Free For Charity has a simple mission with broad implications
         </h2>
-        <p
-          className="font-[700] text-[25px] leading-[150%] tracking-[0] text-center mb-[30px]"
-          id="lato-font"
-        >
+        <p className="font-[700] text-[25px] leading-[150%] tracking-[0] text-center mb-[30px] lato-font">
           Reduce costs and increase revenues for nonprofits; putting that money back into their
           charitable mission where it belongs.
         </p>
-        <p
-          className="font-[500] text-[25px] leading-[150%] tracking-[0] text-center"
-          id="lato-font"
-        >
+        <p className="font-[500] text-[25px] leading-[150%] tracking-[0] text-center lato-font">
           This charity for charities seeks to replace as many functions as possible that current
           nonprofits pay for to for-profit companies with free or at cost work from our campus, on
           site projects, or partnerships with other entities.

--- a/src/components/home-page/Our-Programs/index.tsx
+++ b/src/components/home-page/Our-Programs/index.tsx
@@ -8,10 +8,7 @@ const index = () => {
   return (
     <div id="programs" className="py-[52px]">
       <div className="w-[90%] lg:px-[20px] mx-auto">
-        <h2
-          className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
-          id="faustina-font"
-        >
+        <h2 className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px] faustina-font">
           Our Programs
         </h2>
 
@@ -27,11 +24,9 @@ const index = () => {
                 ></Image>
               </div>
             </div>
-            <h3 className="text-[36px] font-[400] " id="lato-font">
-              FFC Domains
-            </h3>
+            <h3 className="text-[36px] font-[400]  lato-font">FFC Domains</h3>
           </div>
-          <p className="text-[25px] font-[400] " id="lato-font">
+          <p className="text-[25px] font-[400]  lato-font">
             Provides free .org domain names, Microsoft 365 with Outlook email, & Microsoft Teams to
             501c3 charities.
           </p>
@@ -88,11 +83,9 @@ const index = () => {
                 ></Image>
               </div>
             </div>
-            <h3 className="text-[36px] font-[400]  " id="lato-font">
-              FFC Hosting
-            </h3>
+            <h3 className="text-[36px] font-[400]   lato-font">FFC Hosting</h3>
           </div>
-          <p className="text-[25px] font-[400]  " id="lato-font">
+          <p className="text-[25px] font-[400]   lato-font">
             Free static site hosting for nonprofit organizations using Microsoft GitHub Pages, with
             websites built using GitHub Copilot AI:
           </p>
@@ -159,11 +152,9 @@ const index = () => {
                 ></Image>
               </div>
             </div>
-            <h3 className="text-[36px] font-[400]  " id="lato-font">
-              FFC Consulting
-            </h3>
+            <h3 className="text-[36px] font-[400]   lato-font">FFC Consulting</h3>
           </div>
-          <p className="text-[25px] font-[400]  " id="lato-font">
+          <p className="text-[25px] font-[400]   lato-font">
             FFC Consulting is about helping charities get the most out of their digital
             infrastructure including from other charities for charities like ours or from partners.
             We introduce charities to each major service that supports the charity mission of our
@@ -211,7 +202,7 @@ const index = () => {
         </div>
 
         <div className="lg:w-[90%] mx-auto text-center pb-[54px] pt-[20px]">
-          <h3 className="text-[36px] font-[400] pt-[22px] pb-[30px]" id="lato-font">
+          <h3 className="text-[36px] font-[400] pt-[22px] pb-[30px] lato-font">
             Ready to Get Started Now?
           </h3>
 

--- a/src/components/home-page/Results-2023/index.tsx
+++ b/src/components/home-page/Results-2023/index.tsx
@@ -5,10 +5,7 @@ const index = () => {
   return (
     <div id="results">
       <div className="w-[90%] mx-auto py-[52px] lg:px-[20px]">
-        <h2
-          className="mt-[2px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px]  text-center mb-[40px]"
-          id="faustina-font"
-        >
+        <h2 className="mt-[2px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px]  text-center mb-[40px] faustina-font">
           Results - 2023
         </h2>
         <div className="pt-[30px] grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-[20px]">

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -30,20 +30,14 @@ const Index = () => {
   return (
     <div id="donate">
       <div className="w-[90%] mx-auto py-[27px] mb-[60px] px-[20px] max-w-[1280px]">
-        <h2
-          className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[60px]"
-          id="faustina-font"
-        >
+        <h2 className="font-[400] text-[40px] lg:text-[48px] leading-[100%] tracking-[0] text-center mx-auto mb-[60px] faustina-font">
           Support Free For Charity
         </h2>
 
         <div className="flex items-center flex-col lg:flex-row gap-[40px] lg:gap-[20px]">
           {/* Left side: Description and pointing hands image */}
           <div className="flex flex-col w-full lg:w-[50%]">
-            <p
-              className="mb-[20px] font-[400] text-[25px] leading-[150%] tracking-[0] text-center lg:text-left"
-              id="lato-font"
-            >
+            <p className="mb-[20px] font-[400] text-[25px] leading-[150%] tracking-[0] text-center lg:text-left lato-font">
               By donating you help drive our mission and allow us to support more charities with our
               Domain, Website, and other services.
             </p>

--- a/src/components/home-page/Testimonials/index.tsx
+++ b/src/components/home-page/Testimonials/index.tsx
@@ -96,28 +96,22 @@ const TestimonialSlider: React.FC = () => {
                     <Image src={QuoteLeft} alt="Opening quote" width={36} height={36} />
                   </div>
 
-                  <h3
-                    className="text-[22px] font-bold mb-[10px] text-[#333] leading-6 italic"
-                    id="aria-font"
-                  >
+                  <h3 className="text-[22px] font-bold mb-[10px] text-[#333] leading-6 italic aria-font">
                     {t.heading}
                   </h3>
-                  <p
-                    className="text-[17px] font-medium text-black italic px-0 sm:px-4 md:px-8"
-                    id="aria-font"
-                  >
+                  <p className="text-[17px] font-medium text-black italic px-0 sm:px-4 md:px-8 aria-font">
                     {t.text}
                   </p>
 
                   {t.name && (
-                    <p className="text-[14px] font-medium my-2 text-[#666666]" id="aria-font">
+                    <p className="text-[14px] font-medium my-2 text-[#666666] aria-font">
                       {t.name}
                     </p>
                   )}
 
                   {t.location && (
                     <a href="https://americanlegionpost64.org/">
-                      <p className="text-[14px] font-medium text-[#227AB5]" id="aria-font">
+                      <p className="text-[14px] font-medium text-[#227AB5] aria-font">
                         {t.location}
                       </p>
                     </a>

--- a/src/components/home-page/TheFreeForCharityTeam/index.tsx
+++ b/src/components/home-page/TheFreeForCharityTeam/index.tsx
@@ -5,10 +5,7 @@ import { assetPath } from '@/lib/assetPath'
 const index = () => {
   return (
     <div id="team" className="py-[50px]">
-      <h2
-        className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px]"
-        id="faustina-font"
-      >
+      <h2 className="font-[400] text-[40px] lg:text-[48px]  tracking-[0] text-center mx-auto mb-[50px] faustina-font">
         The Free For Charity Team
       </h2>
 

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -6,16 +6,10 @@ const index = () => {
   return (
     <div id="volunteer" className="bg-[#2A6682] py-[40px]">
       <div className="w-[90%] mx-auto lg:px-[20px]">
-        <h2
-          className="mt-[2px] mb-[42px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px] text-center text-white"
-          id="faustina-font"
-        >
+        <h2 className="mt-[2px] mb-[42px] pb-[10px] text-[30px] md:text-[48px] font-[400] leading-[46px] text-center text-white faustina-font">
           Volunteer with Us
         </h2>
-        <p
-          className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center text-white"
-          id="lato-font"
-        >
+        <p className="mb-[13px] w-[85%] mx-auto font-[500] text-[20px] leading-[30px] text-center text-white lato-font">
           Your time and skills can create a lasting impact. Whether youre assisting with outreach,
           providing technical expertise, or supporting our programs, your contributions are
           invaluable to our mission.
@@ -26,8 +20,7 @@ const index = () => {
           rel="noopener noreferrer"
           className="w-[216px] h-[62px] top-[261px] left-[611px] rounded-[27px] 
              flex items-center justify-center px-[32px] py-[18px] gap-[10px] 
-             text-[#113563] mx-auto mt-[30px] bg-white text-[20px] font-[400] font-sans text-center"
-          id="lato-font"
+             text-[#113563] mx-auto mt-[30px] bg-white text-[20px] font-[400] font-sans text-center lato-font"
         >
           Volunteer
         </a>

--- a/src/components/ui/ApplicationFormButton.tsx
+++ b/src/components/ui/ApplicationFormButton.tsx
@@ -93,8 +93,7 @@ const ApplicationFormButton: React.FC<ApplicationFormButtonProps> = ({
           text-black font-[400] text-[25px] px-[28px] py-[16px] 
           hover:bg-[#2A6682] hover:text-white transition-all duration-300
           ${className}
-        `}
-        id="lato-font"
+         lato-font`}
       >
         {text}
       </button>

--- a/src/components/ui/Frequently-Asked-Questions.tsx
+++ b/src/components/ui/Frequently-Asked-Questions.tsx
@@ -26,7 +26,7 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
   const toggle = () => setIsOpen(!isOpen)
 
   return (
-    <div className="mb-5 overflow-hidden" id="lato-font">
+    <div className="mb-5 overflow-hidden lato-font">
       {/* Header */}
       <button
         onClick={toggle}
@@ -34,7 +34,7 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
         aria-expanded={isOpen}
       >
         {/* Text takes remaining space */}
-        <span className={`font-[400] text-[20px] md:text-[32px] flex-1 pr-3`} id="lato-font">
+        <span className={`font-[400] text-[20px] md:text-[32px] flex-1 pr-3 lato-font`}>
           {title}
         </span>
 
@@ -65,8 +65,7 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
       >
         <div
           ref={contentRef}
-          className="px-4 pb-4 pt-2 transition-colors duration-300 text-[#555555] text-[20px] md:text-[25px] font-[400]"
-          id="lato-font"
+          className="px-4 pb-4 pt-2 transition-colors duration-300 text-[#555555] text-[20px] md:text-[25px] font-[400] lato-font"
         >
           {children}
         </div>

--- a/src/components/ui/OrangeFaqItem.tsx
+++ b/src/components/ui/OrangeFaqItem.tsx
@@ -26,10 +26,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
   const toggle = () => setIsOpen(!isOpen)
 
   return (
-    <div
-      className="shadow-[0px_16px_16px_0px_#11253E0F] mb-5 p-2 border-[5px] border-[#F58629] rounded-[10px] overflow-hidden"
-      id="lato-font"
-    >
+    <div className="shadow-[0px_16px_16px_0px_#11253E0F] mb-5 p-2 border-[5px] border-[#F58629] rounded-[10px] overflow-hidden lato-font">
       {/* Header */}
       <button
         onClick={toggle}
@@ -62,8 +59,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
       >
         <div
           ref={contentRef}
-          className="px-4 pb-4 pt-2 text-[22px] lg:text-[25px] font-[400]"
-          id="lato-font"
+          className="px-4 pb-4 pt-2 text-[22px] lg:text-[25px] font-[400] lato-font"
         >
           {children}
         </div>

--- a/src/components/ui/ResultCard.tsx
+++ b/src/components/ui/ResultCard.tsx
@@ -13,12 +13,10 @@ const ResultCard: React.FC<ResultCardProps> = ({ title, description }) => {
 
   return (
     <div className="w-full h-[300px] px-[20px] flex items-center justify-center flex-col border-[5px] border-[#F58629] rounded-[20px] shadow-[0px_16px_16px_0px_#11253E0F]">
-      <h3 className="text-[64px] font-[400]" id="faustina-font">
+      <h3 className="text-[64px] font-[400] faustina-font">
         {!isNaN(numericValue) ? <AnimatedNumber value={numericValue} /> : title}
       </h3>
-      <p className="text-center text-[25px] font-[400]" id="lato-font">
-        {description}
-      </p>
+      <p className="text-center text-[25px] font-[400] lato-font">{description}</p>
     </div>
   )
 }

--- a/src/components/ui/SustainableFundingCard.tsx
+++ b/src/components/ui/SustainableFundingCard.tsx
@@ -23,16 +23,10 @@ export const SustainableFundingCard: React.FC<SustainableFundingCardProps> = ({
 
       {/* Content Section */}
       <div className="p-4 text-center">
-        <h3
-          className="text-[24px] lg:text-[28px] font-[400] text-[#000000] leading-[100%] mb-3"
-          id="lato-font"
-        >
+        <h3 className="text-[24px] lg:text-[28px] font-[400] text-[#000000] leading-[100%] mb-3 lato-font">
           {title}
         </h3>
-        <p
-          className="text-[16px] sm:text-[18px] font-[400] text-[#000000] leading-[140%]"
-          id="lato-font"
-        >
+        <p className="text-[16px] sm:text-[18px] font-[400] text-[#000000] leading-[140%] lato-font">
           {text}
         </p>
       </div>

--- a/src/components/ui/TeamMemberCard.tsx
+++ b/src/components/ui/TeamMemberCard.tsx
@@ -34,12 +34,8 @@ export default function TeamMemberCard({
 
         {/* Text Content */}
         <div className="text-center space-y-2">
-          <h3 className="text-[32px] font-[400]" id="lato-font">
-            {name}
-          </h3>
-          <p className="text-[25px] font-[400]" id="lato-font">
-            {title}
-          </p>
+          <h3 className="text-[32px] font-[400] lato-font">{name}</h3>
+          <p className="text-[25px] font-[400] lato-font">{title}</p>
         </div>
 
         {/* LinkedIn Button */}


### PR DESCRIPTION
Bundles two closely-related correctness fixes (they overlap on the same policy-page link elements, so they're cleaner together).

## 1. Duplicate `id="*-font"` → classes (HTML validity)

`id="*-font"` was used as global font-family hooks, but the same ID repeated across many elements — `id="lato-font"` ×34, `id="aria-font"` ×14, `id="faustina-font"` ×11 (**59 total**). Duplicate IDs are invalid HTML.

- Converted all 59 to class names, merged into each element's existing `className`.
- Switched the three live global rules `#aria-font`/`#lato-font`/`#faustina-font` → `.aria-font`/`.lato-font`/`.faustina-font`.
- Verified the built CSS emits `.aria-font{font-family:…}` and elements carry the class; every remaining `id` in `src` is now unique.

## 2. Policy-page a11y (Lighthouse `heading-order` + `color-contrast`)

The policy pages were below AA on two audits (home was already clean from the earlier a11y PRs):

- **heading-order**: the shared **footer** used `<h3>`/`<h4>` titles, which skipped a level after the policy pages' `<h1>` content. Promoted footer titles to `<h2>` (nested one to `<h3>`) — valid on every page, home included (`h2` sections → `h2` footer).
- **color-contrast**: the `#007bff` links on white were 3.97:1 (AA needs 4.5). Darkened to `#0062CC` (5.8:1) in the three policy pages that use it.

## Verified (local Lighthouse + checks)

- **home, terms-of-service, privacy-policy all now report Accessibility 100%** with `heading-order` and `color-contrast` passing.
- `npm run lint` 0 errors, `check:drift` clean, `npm test` 91/91, `npm run build` succeeds.

## Note

`globals.css` still has unused `#*-font` rules (montserrat, cinzel, segoe…) from deleted components — dead CSS, not a duplicate-ID problem. Easy to remove in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)