### PR TITLE
perf: drop 5 unused web fonts (Performance 75 → 89)

### DIFF
--- a/__tests__/lib/fonts.test.ts
+++ b/__tests__/lib/fonts.test.ts
@@ -13,36 +13,17 @@ jest.mock('next/font/google', () => {
   return {
     Open_Sans: echo,
     Lato: echo,
-    Raleway: echo,
     Faustina: echo,
-    Cantata_One: echo,
-    Fauna_One: echo,
-    Montserrat: echo,
-    Cinzel: echo,
   }
 })
 
-import {
-  openSans,
-  lato,
-  raleway,
-  faustina,
-  cantataOne,
-  faunaOne,
-  montserrat,
-  cinzel,
-} from '../../src/lib/fonts'
+import { openSans, lato, faustina } from '../../src/lib/fonts'
 
 describe('fonts module exports', () => {
   const allFonts = {
     openSans,
     lato,
-    raleway,
     faustina,
-    cantataOne,
-    faunaOne,
-    montserrat,
-    cinzel,
   } as const
 
   it('exports a defined font object for every named Google font', () => {
@@ -61,12 +42,7 @@ describe('fonts module exports', () => {
     const expected: Record<keyof typeof allFonts, string> = {
       openSans: '--font-open-sans',
       lato: '--font-lato',
-      raleway: '--font-raleway',
       faustina: '--font-faustina',
-      cantataOne: '--font-cantata-one',
-      faunaOne: '--font-fauna-one',
-      montserrat: '--font-montserrat',
-      cinzel: '--font-cinzel',
     }
 
     for (const [name, font] of Object.entries(allFonts)) {
@@ -93,12 +69,7 @@ describe('fonts module exports', () => {
     const expectedWeight: Record<keyof typeof allFonts, string | string[]> = {
       openSans: ['400', '500', '600', '700', '800'],
       lato: ['400', '700'],
-      raleway: ['400', '500', '600', '700'],
       faustina: ['400', '500', '600', '700'],
-      cantataOne: '400',
-      faunaOne: '400',
-      montserrat: ['400', '500', '600', '700'],
-      cinzel: ['400', '500', '600', '700'],
     }
 
     for (const [name, font] of Object.entries(allFonts)) {
@@ -110,18 +81,7 @@ describe('fonts module exports', () => {
     }
   })
 
-  it('exports exactly the eight expected font instances', () => {
-    expect(Object.keys(allFonts).sort()).toEqual(
-      [
-        'cantataOne',
-        'cinzel',
-        'faunaOne',
-        'faustina',
-        'lato',
-        'montserrat',
-        'openSans',
-        'raleway',
-      ].sort()
-    )
+  it('exports exactly the three expected font instances', () => {
+    expect(Object.keys(allFonts).sort()).toEqual(['faustina', 'lato', 'openSans'].sort())
   })
 })

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,7 +32,7 @@ body {
 
   /* Fonts (provided via next/font and CSS variables on <body>) */
   --font-serif-display: var(--font-faustina);
-  --font-serif: var(--font-fauna-one);
+  --font-serif: var(--font-faustina);
   --font-sans: var(--font-lato);
 }
 
@@ -49,31 +49,6 @@ body {
 }
 .lato-font {
   font-family: var(--font-lato), sans-serif !important;
-}
-#montserrat-font {
-  font-family: var(--font-montserrat), sans-serif !important;
-}
-#abeezee {
-  font-family: var(--font-open-sans), sans-serif !important;
-}
-/* Segoe UI is a system font - use native system font stack for best performance (only used 2x) */
-#segoe-font {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif !important;
-}
-#cinzel {
-  font-family: var(--font-cinzel), serif !important;
-}
-#fauna-font {
-  font-family: var(--font-fauna-one), serif !important;
-}
-#cantata-font {
-  font-family: var(--font-cantata-one), serif !important;
-}
-#raleway-font {
-  font-family: var(--font-raleway), sans-serif !important;
-}
-#courier-font {
-  font-family: ui-monospace, 'Courier New', monospace !important;
 }
 .faustina-font {
   font-family: var(--font-faustina), serif !important;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,16 +6,7 @@ import CookieConsent from './../components/cookie-consent'
 import GoogleTagManager, { GoogleTagManagerNoScript } from './../components/google-tag-manager'
 import { siteConfig, siteUrl, twitterSite, cardDescription } from '@/lib/site.config'
 import { assetPath } from '@/lib/assetPath'
-import {
-  openSans,
-  lato,
-  raleway,
-  faustina,
-  cantataOne,
-  faunaOne,
-  montserrat,
-  cinzel,
-} from '@/lib/fonts'
+import { openSans, lato, faustina } from '@/lib/fonts'
 
 const defaultTitle = `${siteConfig.name} | ${siteConfig.tagline}`
 
@@ -117,17 +108,7 @@ export default function RootLayout({
         <GoogleTagManager />
       </head>
       <body
-        className={[
-          'antialiased',
-          openSans.variable,
-          lato.variable,
-          raleway.variable,
-          faustina.variable,
-          cantataOne.variable,
-          faunaOne.variable,
-          montserrat.variable,
-          cinzel.variable,
-        ].join(' ')}
+        className={['antialiased', openSans.variable, lato.variable, faustina.variable].join(' ')}
         suppressHydrationWarning={true}
       >
         <GoogleTagManagerNoScript />

--- a/src/lib/fonts.ts
+++ b/src/lib/fonts.ts
@@ -1,15 +1,13 @@
-import {
-  Open_Sans,
-  Lato,
-  Raleway,
-  Faustina,
-  Cantata_One,
-  Fauna_One,
-  Montserrat,
-  Cinzel,
-} from 'next/font/google'
+import { Open_Sans, Lato, Faustina } from 'next/font/google'
 
-// Configure fonts with proper subsets and display strategy
+// Only the three font families actually used by the template are loaded:
+//   - Open Sans  -> .aria-font / #header
+//   - Lato       -> .lato-font (and Tailwind --font-sans)
+//   - Faustina   -> body default / .faustina-font (and --font-serif-display)
+// Earlier the template loaded eight families; the others (Raleway, Cantata
+// One, Fauna One, Montserrat, Cinzel) were only referenced by components that
+// have since been removed, so loading them just cost bytes and main-thread
+// work. Add a family back here (and a matching CSS rule) if you start using it.
 export const openSans = Open_Sans({
   subsets: ['latin'],
   display: 'swap',
@@ -24,44 +22,9 @@ export const lato = Lato({
   weight: ['400', '700'],
 })
 
-export const raleway = Raleway({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-raleway',
-  weight: ['400', '500', '600', '700'],
-})
-
 export const faustina = Faustina({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-faustina',
-  weight: ['400', '500', '600', '700'],
-})
-
-export const cantataOne = Cantata_One({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-cantata-one',
-  weight: '400',
-})
-
-export const faunaOne = Fauna_One({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-fauna-one',
-  weight: '400',
-})
-
-export const montserrat = Montserrat({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-montserrat',
-  weight: ['400', '500', '600', '700'],
-})
-
-export const cinzel = Cinzel({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-cinzel',
   weight: ['400', '500', '600', '700'],
 })


### PR DESCRIPTION
## Diagnosis

Lighthouse Performance was 75%, dragged almost entirely by **LCP (5.3s)**. The LCP phase breakdown showed the hero image **loads instantly** (preloaded, 0ms) — the cost was **91% Render Delay**, gated on ~3.7s of main-thread work. A big chunk of that: the layout loaded **8 Google font families** (≈ a couple hundred KB of woff2 + parsing), but after the earlier component cleanup only **3 are actually used**.

## Fix

Load only the fonts in use — **Open Sans** (`.aria-font`/`#header`), **Lato** (`.lato-font`), **Faustina** (body/`.faustina-font`). Removed **Raleway, Cantata One, Fauna One, Montserrat, Cinzel** (referenced only by deleted components + dead `#*-font` CSS rules). Also deleted the dead `#*-font`/`#abeezee`/`#segoe-font`/`#courier-font` rules and repointed the unused `--font-serif` token to Faustina.

## Measured (local Lighthouse, simulated throttling)

| Metric | Before | After |
|--------|--------|-------|
| **Performance** | 75% | **89%** |
| LCP | 5.3 s | **3.6 s** |
| Speed Index | 5.0 s | **1.8 s** |
| Total Blocking Time | 100 ms | 50 ms |
| Font requests | ~all 8 families | 3 families |

`npm run lint` 0 errors, `check:drift` clean, `npm test` 91/91, `npm run build` succeeds.

## Remaining performance headroom (separate work)

LCP render-delay (~2.5s) still comes from main-thread JS (framer-motion, swiper, react-icons). Further gains would need bundle work — dynamic-importing below-the-fold components, lighter icon imports — which is riskier and worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_