### PR TITLE
refactor: consolidate icon libraries onto react-icons, drop lucide-react

### DIFF
--- a/FACEBOOK_EVENTS_SETUP.md
+++ b/FACEBOOK_EVENTS_SETUP.md
@@ -765,7 +765,7 @@ Create `src/components/home-page/Events/EventCard.tsx`:
 
 ```typescript
 import React from 'react'
-import { Calendar, MapPin, Clock } from 'lucide-react'
+import { FiCalendar, FiMapPin, FiClock } from 'react-icons/fi'
 
 interface EventCardProps {
   id: string
@@ -821,12 +821,12 @@ const EventCard: React.FC<EventCardProps> = ({
 
       <div className="space-y-2 mb-4">
         <div className="flex items-center text-gray-600">
-          <Calendar className="w-5 h-5 mr-2 text-orange-500" />
+          <FiCalendar className="w-5 h-5 mr-2 text-orange-500" />
           <span id="lato-font">{formatDate(startTime)}</span>
         </div>
 
         <div className="flex items-center text-gray-600">
-          <Clock className="w-5 h-5 mr-2 text-orange-500" />
+          <FiClock className="w-5 h-5 mr-2 text-orange-500" />
           <span id="lato-font">
             {formatTime(startTime)}
             {endTime && ` - ${formatTime(endTime)}`}
@@ -835,7 +835,7 @@ const EventCard: React.FC<EventCardProps> = ({
 
         {place && (
           <div className="flex items-center text-gray-600">
-            <MapPin className="w-5 h-5 mr-2 text-orange-500" />
+            <FiMapPin className="w-5 h-5 mr-2 text-orange-500" />
             <span id="lato-font">
               {place.name}
               {place.location && `, ${place.location.city}, ${place.location.state}`}

--- a/SITE_IMPROVEMENTS.md
+++ b/SITE_IMPROVEMENTS.md
@@ -88,13 +88,13 @@ This analysis compares FFC_Single_Page_Template against three sister repositorie
 
 ### Dependency Comparison
 
-| Library/Tool         | FFC_Single_Page_Template | freeforcharity-web | ffcadmin.org | KCCF-web |
-| -------------------- | ------------------------ | ------------------ | ------------ | -------- |
-| **framer-motion**    | ✅ 12.23.24              | ✅ 12.23.24        | ❌           | ❌       |
-| **lucide-react**     | ✅ 0.469.0               | ✅ 0.469.0         | ❌           | ❌       |
-| **react-icons**      | ✅ 5.5.0                 | ✅ 5.5.0           | ❌           | ❌       |
-| **swiper**           | ✅ 12.0.3                | ✅ 12.0.3          | ❌           | ❌       |
-| **@playwright/test** | ✅ 1.56.0                | ✅ 1.56.0          | ❌           | ❌       |
+| Library/Tool         | FFC_Single_Page_Template     | freeforcharity-web | ffcadmin.org | KCCF-web |
+| -------------------- | ---------------------------- | ------------------ | ------------ | -------- |
+| **framer-motion**    | ✅ 12.23.24                  | ✅ 12.23.24        | ❌           | ❌       |
+| **lucide-react**     | ❌ removed (use react-icons) | ✅ 0.469.0         | ❌           | ❌       |
+| **react-icons**      | ✅ 5.5.0                     | ✅ 5.5.0           | ❌           | ❌       |
+| **swiper**           | ✅ 12.0.3                    | ✅ 12.0.3          | ❌           | ❌       |
+| **@playwright/test** | ✅ 1.56.0                    | ✅ 1.56.0          | ❌           | ❌       |
 
 **Observation:** FFC_Single_Page_Template and freeforcharity-web are nearly identical in their dependency stacks, suggesting they share similar feature sets.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "framer-motion": "^12.39.0",
-        "lucide-react": "^0.555.0",
         "next": "^16.2.6",
         "postcss": "^8.5.14",
         "react": "19.2.6",
@@ -11737,15 +11736,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.555.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.555.0.tgz",
-      "integrity": "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "framer-motion": "^12.39.0",
-    "lucide-react": "^0.555.0",
     "next": "^16.2.6",
     "postcss": "^8.5.14",
     "react": "19.2.6",

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -2,21 +2,19 @@
 
 import React from 'react'
 import Link from 'next/link'
-import { Mail, Phone, MapPin, ArrowRight, Link2 } from 'lucide-react'
-
+import { FiMail, FiPhone, FiMapPin, FiArrowRight, FiLink2 } from 'react-icons/fi'
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
 import type { IconType } from 'react-icons'
-import type { LucideIcon } from 'lucide-react'
 
 import { siteConfig } from '@/lib/site.config'
 import { assetPath } from '@/lib/assetPath'
 
 // Maps a social link's label (as defined in siteConfig.social) to an icon.
-// Unknown labels fall back to a generic link icon (Link2 from lucide-react)
-// so a charity that adds a new social network — Bluesky, Mastodon, YouTube,
-// etc. — gets a sensible placeholder instead of a misleading GitHub mark.
-const socialIconByLabel: Record<string, IconType | LucideIcon> = {
+// Unknown labels fall back to a generic link icon (FiLink2) so a charity
+// that adds a new social network — Bluesky, Mastodon, YouTube, etc. — gets a
+// sensible placeholder instead of a misleading GitHub mark.
+const socialIconByLabel: Record<string, IconType> = {
   Facebook: FaFacebookF,
   'X (Twitter)': FaXTwitter,
   Twitter: FaXTwitter,
@@ -55,7 +53,7 @@ const Footer: React.FC = () => {
                 Direct GuideStar Profile Link
               </span>
 
-              <ArrowRight
+              <FiArrowRight
                 className="h-8 w-8 translate-x-2 opacity-0 text-[#2ea3f2] transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100"
                 strokeWidth={2}
               />
@@ -150,7 +148,7 @@ const Footer: React.FC = () => {
 
           <div className="space-y-4 text-sm">
             <div className="flex items-start gap-3">
-              <Mail className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
+              <FiMail className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">E-mail</p>
                 <a
@@ -163,7 +161,7 @@ const Footer: React.FC = () => {
             </div>
 
             <div className="flex items-start gap-3">
-              <Phone className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
+              <FiPhone className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">Call Us Today</p>
                 <a
@@ -182,7 +180,7 @@ const Footer: React.FC = () => {
               aria-label="Open main address in Google Maps"
               className="flex items-start gap-3 hover:opacity-80 transition-opacity"
             >
-              <MapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
+              <FiMapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">Main Address</p>
                 <p className="font-[500] text-[16px] aria-font">
@@ -202,7 +200,7 @@ const Footer: React.FC = () => {
               aria-label="Open PA office address in Google Maps"
               className="flex items-start gap-3 hover:opacity-80 transition-opacity"
             >
-              <MapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
+              <FiMapPin className="w-10 h-10 text-orange-500 flex-shrink-0 mt-0.5" />
               <div>
                 <p className="font-[500] text-[22px]">PA Office Address</p>
                 <p className="font-[500] text-[16px] aria-font">
@@ -215,7 +213,7 @@ const Footer: React.FC = () => {
 
             <div className="flex gap-3 pt-4">
               {socialLinks.map(({ href, label }) => {
-                const Icon = socialIconByLabel[label] ?? Link2
+                const Icon = socialIconByLabel[label] ?? FiLink2
                 return (
                   <a
                     key={`${label}-${href}`}


### PR DESCRIPTION
## Description

The template shipped **two** icon packages. `react-icons` was already used across the header and testimonials; `lucide-react` was used in only one place — the footer — for five glyphs (`Mail`, `Phone`, `MapPin`, `ArrowRight`, `Link2`). lucide is a fork of Feather, and `react-icons` already bundles Feather as its `fi` set, so each glyph has a pixel-identical counterpart (`FiMail`, `FiPhone`, `FiMapPin`, `FiArrowRight`, `FiLink2`). Swapping them lets us drop `lucide-react` entirely.

Benefits: one fewer runtime dependency and supply-chain surface, smaller install/bundle footprint, and a single icon system for contributors to learn. **No visual change** — Feather glyphs are identical.

## Type of Change

- [x] Code refactoring
- [x] Performance improvement

## Related Issue(s)

N/A — follow-up enhancement identified while working the performance issues.

## Changes Made

- `src/components/footer/index.tsx`: replaced the five `lucide-react` imports with the equivalent `react-icons/fi` glyphs; dropped the `LucideIcon` type from the social-icon map (now `Record<string, IconType>`).
- `package.json` / `package-lock.json`: removed `lucide-react`.
- `FACEBOOK_EVENTS_SETUP.md`: updated the example `EventCard` to import from `react-icons/fi`.
- `SITE_IMPROVEMENTS.md`: marked `lucide-react` as removed in the dependency comparison.

## Testing Performed

### Automated Testing

- [x] `npm run lint` — passes (only the two pre-existing `<img>` warnings)
- [x] `npm test` — 91/91 unit tests pass
- [x] `npm run build` — static export completes successfully
- [x] `npm run check:drift` — no drift

### Accessibility

- [x] Color contrast meets WCAG standards (unchanged — same glyphs, same colors)

## Breaking Changes

None / N/A

## Additional Notes

Part of the post-performance enhancement pass. Verified no remaining `lucide` references under `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_