### PR TITLE
fix: accessible FAQ accordions, JSON-LD hardening, dead-code cleanup

### DIFF
--- a/__tests__/components/ui/FaqAccordion.test.tsx
+++ b/__tests__/components/ui/FaqAccordion.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import FrequentlyAskedQuestions from '../../../src/components/ui/Frequently-Asked-Questions'
+import OrangeFaqItem from '../../../src/components/ui/OrangeFaqItem'
+
+// Both accordion components share the same accessibility contract: the toggle
+// button is associated with its collapsible panel via aria-controls /
+// aria-labelledby, exposes aria-expanded, and the toggle icon's alt text
+// reflects the action (Expand / Collapse).
+describe.each([
+  ['Frequently-Asked-Questions', FrequentlyAskedQuestions],
+  ['OrangeFaqItem', OrangeFaqItem],
+])('%s accordion accessibility', (_name, Accordion) => {
+  it('links the toggle button to its panel via aria-controls', () => {
+    const { container } = render(
+      <Accordion title="What is this?">
+        <p>Answer body</p>
+      </Accordion>
+    )
+    const button = screen.getByRole('button')
+    const panelId = button.getAttribute('aria-controls')
+    expect(panelId).toBeTruthy()
+
+    const panel = container.querySelector(`#${panelId}`)
+    expect(panel).not.toBeNull()
+    expect(panel).toHaveAttribute('aria-labelledby', button.id)
+    expect(button.id).toBeTruthy()
+  })
+
+  it('reflects open/closed state in aria-expanded and icon alt text', () => {
+    render(
+      <Accordion title="What is this?">
+        <p>Answer body</p>
+      </Accordion>
+    )
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByAltText('Expand')).toBeInTheDocument()
+
+    fireEvent.click(button)
+
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByAltText('Collapse')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/ui/FaqAccordion.test.tsx
+++ b/__tests__/components/ui/FaqAccordion.test.tsx
@@ -21,7 +21,9 @@ describe.each([
     const panelId = button.getAttribute('aria-controls')
     expect(panelId).toBeTruthy()
 
-    const panel = container.querySelector(`#${panelId}`)
+    // Use an attribute selector rather than `#${panelId}`: useId() ids can
+    // contain ':' which a CSS id selector treats as a pseudo-class separator.
+    const panel = container.querySelector(`[id="${panelId}"]`)
     expect(panel).not.toBeNull()
     expect(panel).toHaveAttribute('aria-labelledby', button.id)
     expect(button.id).toBeTruthy()

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -119,13 +119,10 @@ export default function RootLayout({
         <a href="#main-content" className="skip-to-content">
           Skip to main content
         </a>
-        {/* <PopupProvider> */}
         <Header />
         <main id="main-content">{children}</main>
         <Footer />
         <CookieConsent />
-        {/* <PopupsRootClient /> */}
-        {/* </PopupProvider> */}
       </body>
     </html>
   )

--- a/src/components/seo/OrganizationSchema.tsx
+++ b/src/components/seo/OrganizationSchema.tsx
@@ -40,13 +40,16 @@ export function buildOrganizationSchema(): Record<string, unknown> {
  */
 export default function OrganizationSchema() {
   const schema = buildOrganizationSchema()
+  // Escape '<' as its JSON unicode form so any value that ever contains the
+  // literal substring "</script>" cannot break out of this inline script tag
+  // (a known JSON-LD injection vector). The output stays valid JSON/JSON-LD.
+  const json = JSON.stringify(schema).replace(/</g, '\\u003c')
   return (
     <script
       type="application/ld+json"
-      // Stable JSON output: stringify with no whitespace to avoid layout
-      // shift and keep the payload small. dangerouslySetInnerHTML is the
-      // standard pattern for inline JSON-LD per the Next.js docs.
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      // dangerouslySetInnerHTML is the standard pattern for inline JSON-LD per
+      // the Next.js docs.
+      dangerouslySetInnerHTML={{ __html: json }}
     />
   )
 }

--- a/src/components/ui/Frequently-Asked-Questions.tsx
+++ b/src/components/ui/Frequently-Asked-Questions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useRef, useLayoutEffect } from 'react'
+import React, { useState, useRef, useLayoutEffect, useId } from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
@@ -13,6 +13,11 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
   const [isOpen, setIsOpen] = useState(false)
   const [height, setHeight] = useState('0px')
   const contentRef = useRef<HTMLDivElement>(null)
+  // Stable, SSR-safe ids so the toggle button and its collapsible panel can be
+  // associated for assistive tech (aria-controls + aria-labelledby).
+  const baseId = useId()
+  const buttonId = `${baseId}-button`
+  const panelId = `${baseId}-panel`
 
   // Using useLayoutEffect (not useEffect) for synchronous DOM measurement before paint
   // This is the correct React pattern to avoid visual flicker when measuring and updating height
@@ -29,9 +34,11 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
     <div className="mb-5 overflow-hidden lato-font">
       {/* Header */}
       <button
+        id={buttonId}
         onClick={toggle}
         className={`w-full px-4 py-3 flex items-center justify-between text-left cursor-pointer`}
         aria-expanded={isOpen}
+        aria-controls={panelId}
       >
         {/* Text takes remaining space */}
         <span className={`font-[400] text-[20px] md:text-[32px] flex-1 pr-3 lato-font`}>
@@ -43,14 +50,14 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
           {isOpen ? (
             <Image
               src={assetPath('/Svgs/up-arrow.svg')}
-              alt="up arrow"
+              alt="Collapse"
               width={40}
               height={13}
             ></Image>
           ) : (
             <Image
               src={assetPath('/Svgs/down-arrow.svg')}
-              alt="up arrow"
+              alt="Expand"
               width={40}
               height={16}
             ></Image>
@@ -60,6 +67,9 @@ const FrequentlyAskedQuestions: React.FC<AccordionItemProps> = ({ title, childre
 
       {/* Content */}
       <div
+        id={panelId}
+        role="region"
+        aria-labelledby={buttonId}
         className={`border-b-[2px] border-[#B7B7B7] overflow-hidden transition-all duration-800 ease-in-out`}
         style={{ maxHeight: height }}
       >

--- a/src/components/ui/OrangeFaqItem.tsx
+++ b/src/components/ui/OrangeFaqItem.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useRef, useLayoutEffect } from 'react'
+import React, { useState, useRef, useLayoutEffect, useId } from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
 
@@ -13,6 +13,11 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
   const [isOpen, setIsOpen] = useState(false)
   const [height, setHeight] = useState('0px')
   const contentRef = useRef<HTMLDivElement>(null)
+  // Stable, SSR-safe ids so the toggle button and its collapsible panel can be
+  // associated for assistive tech (aria-controls + aria-labelledby).
+  const baseId = useId()
+  const buttonId = `${baseId}-button`
+  const panelId = `${baseId}-panel`
 
   // Using useLayoutEffect (not useEffect) for synchronous DOM measurement before paint
   // This is the correct React pattern to avoid visual flicker when measuring and updating height
@@ -29,11 +34,13 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
     <div className="shadow-[0px_16px_16px_0px_#11253E0F] mb-5 p-2 border-[5px] border-[#F58629] rounded-[10px] overflow-hidden lato-font">
       {/* Header */}
       <button
+        id={buttonId}
         onClick={toggle}
         className={`w-full px-4 py-3 flex items-center justify-between text-left transition-colors duration-300 cursor-pointer ${
           isOpen ? 'bg-white/90' : 'bg-none'
         }`}
         aria-expanded={isOpen}
+        aria-controls={panelId}
       >
         <span
           className={`font-[400] text-[28px] lg:text-[36px] leading-[100%] flex-1 pr-3 transition-colors duration-300`}
@@ -43,15 +50,18 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ title, children }) => {
 
         <span className="flex-shrink-0 w-8 h-8 flex items-center justify-center">
           {isOpen ? (
-            <Image width={51} height={51} src={assetPath('/Svgs/minus.svg')} alt="Minus" />
+            <Image width={51} height={51} src={assetPath('/Svgs/minus.svg')} alt="Collapse" />
           ) : (
-            <Image width={51} height={51} src={assetPath('/Svgs/plus.svg')} alt="Plus" />
+            <Image width={51} height={51} src={assetPath('/Svgs/plus.svg')} alt="Expand" />
           )}
         </span>
       </button>
 
       {/* Content */}
       <div
+        id={panelId}
+        role="region"
+        aria-labelledby={buttonId}
         className={`overflow-hidden transition-all duration-800 ease-in-out ${
           isOpen ? 'bg-white/90' : 'bg-white'
         }`}


### PR DESCRIPTION
## Description

Accessibility, security-hygiene, and cleanup polish identified in the template survey.

## Type of Change

- [x] Bug fix (accessibility)
- [x] Code refactoring

## Changes Made

**Accessibility (WCAG 4.1.2 — Name, Role, Value):**
- Associate each FAQ accordion's toggle button with its collapsible panel via `aria-controls` / `aria-labelledby` (stable SSR-safe ids from `useId`) in both `Frequently-Asked-Questions` and `OrangeFaqItem`; mark the panel `role="region"`. Screen readers can now correlate which button expands which panel.
- Fix the toggle-icon alt text to reflect the action: **"Expand"** when collapsed, **"Collapse"** when open (previously both arrows said "up arrow"; `OrangeFaqItem` said generic "Plus"/"Minus").
- New unit test covering the `aria-controls` wiring and alt-text state for both accordion components.

**Hardening:**
- Escape `<` → `<` in `OrganizationSchema`'s inline JSON-LD so a value containing `</script>` cannot break out of the script tag (matches the fix already applied to `FaqSchema` in #359).

**Cleanup:**
- Remove dead commented-out `PopupProvider`/`PopupsRootClient` markup from `layout.tsx`.

## Testing Performed

### Automated Testing

- [x] `npm run lint` — passes (pre-existing `<img>` warnings only)
- [x] `npm test` — 95/95 unit tests pass (4 new)
- [x] `npm run build` — static export succeeds
- [x] `npm run check:drift` — no drift

### Accessibility

- [x] Keyboard navigation works correctly
- [x] Screen reader compatibility improved (button↔panel association)

## Breaking Changes

None / N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_