### PR TITLE
feat: centralize analytics IDs in an editable config file

### DIFF
--- a/EXTERNAL_DEPENDENCIES.md
+++ b/EXTERNAL_DEPENDENCIES.md
@@ -27,7 +27,7 @@ These are services we directly integrate into our application code.
 #### 1. Google Tag Manager (GTM)
 
 - **Purpose:** Tag management system for analytics and marketing pixels
-- **GTM ID:** `GTM-TQ5H8HPR`
+- **GTM ID:** `GTM-TQ5H8HPR` (configured in `src/lib/analytics.config.ts`)
 - **Implementation:** `src/components/google-tag-manager/index.tsx`
 - **Load Strategy:** `lazyOnload` for better performance
 - **Data Collected:** Page views, user interactions, custom events

--- a/TEMPLATE_CUSTOMIZATION.md
+++ b/TEMPLATE_CUSTOMIZATION.md
@@ -38,6 +38,26 @@ charity's name, URL, contact email, social links, etc.
 After editing, **run `npm run check:drift`** to confirm nothing else still
 references the old placeholder values.
 
+## Analytics & tracking IDs
+
+All analytics identifiers live in one file:
+[`src/lib/analytics.config.ts`](./src/lib/analytics.config.ts). They are **not**
+secrets — they are public, client-side IDs baked into the static export and
+visible in the page source — so they are kept in a plain, easy-to-edit config
+file rather than in environment variables or hardcoded inside components.
+
+| Field              | Provider              | Placeholder          |
+| ------------------ | --------------------- | -------------------- |
+| `gtmId`            | Google Tag Manager    | `GTM-TQ5H8HPR` (FFC) |
+| `gaMeasurementId`  | Google Analytics 4    | `G-XXXXXXXXXX`       |
+| `metaPixelId`      | Meta (Facebook) Pixel | `XXXXXXXXXXXXXXX`    |
+| `clarityProjectId` | Microsoft Clarity     | `XXXXXXXXXX`         |
+
+To use your own accounts, edit the values in `analytics.config.ts`. Leaving a
+value as its placeholder keeps that integration effectively inert. The GTM
+component and the cookie-consent component both read from this file, and the
+E2E tests assert against it, so there is a single source of truth.
+
 ## Files you'll likely touch when rebranding
 
 | File                                                            | What to change                                                                                                                                                                                                        |

--- a/src/components/cookie-consent/index.tsx
+++ b/src/components/cookie-consent/index.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'next/link'
+import { analyticsConfig } from '@/lib/analytics.config'
 
-// Environment variables for tracking IDs (replace with actual values)
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-XXXXXXXXXX'
-const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || 'XXXXXXXXXXXXXXX'
-const CLARITY_PROJECT_ID = process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || 'XXXXXXXXXX'
+// Tracking IDs live in src/lib/analytics.config.ts — edit them there.
+const GA_MEASUREMENT_ID = analyticsConfig.gaMeasurementId
+const META_PIXEL_ID = analyticsConfig.metaPixelId
+const CLARITY_PROJECT_ID = analyticsConfig.clarityProjectId
 
 // Define type for GTM dataLayer events
 interface DataLayerEvent {

--- a/src/components/google-tag-manager/README.md
+++ b/src/components/google-tag-manager/README.md
@@ -20,23 +20,26 @@ Google Tag Manager (GTM) is a tag management system that allows you to manage an
 - ✅ Uses Next.js Script component with `afterInteractive` strategy
 - ✅ Includes noscript fallback for accessibility
 - ✅ Integrates with existing cookie consent system
-- ✅ GTM ID hardcoded directly in component (no environment variable needed)
+- ✅ GTM ID read from `src/lib/analytics.config.ts` (one place for all analytics IDs)
 
 ## Configuration
 
 ### Setting Your GTM ID
 
-The GTM container ID is hardcoded directly in the component file. To update it:
+The GTM container ID lives in `src/lib/analytics.config.ts` alongside the other
+analytics IDs. To update it:
 
-1. Open `src/components/GoogleTagManager/index.tsx`
-2. Update the `GTM_ID` constant with your actual GTM container ID:
+1. Open `src/lib/analytics.config.ts`
+2. Set the `gtmId` field to your actual GTM container ID:
 
-```tsx
-// Google Tag Manager ID - Update this with your actual GTM container ID
-const GTM_ID = 'GTM-XXXXXXX' // Replace with your actual GTM ID
+```ts
+export const analyticsConfig = {
+  gtmId: 'GTM-ABC1234', // your GTM container ID
+  // ...
+}
 ```
 
-Replace `GTM-XXXXXXX` with your actual GTM container ID from Google Tag Manager (e.g., `GTM-ABC1234`).
+Replace the value with your actual GTM container ID from Google Tag Manager (e.g., `GTM-ABC1234`).
 
 ## Usage
 
@@ -209,10 +212,10 @@ Note: Ad blockers may prevent GTM from loading. This is expected behavior and af
 
 To change the GTM container ID:
 
-1. Open `src/components/GoogleTagManager/index.tsx`
-2. Update the `GTM_ID` constant:
-   ```tsx
-   const GTM_ID = 'GTM-NEW1234' // Your new GTM ID
+1. Open `src/lib/analytics.config.ts`
+2. Update the `gtmId` field:
+   ```ts
+   gtmId: 'GTM-NEW1234', // Your new GTM ID
    ```
 3. Commit and push the changes
 4. The changes will be deployed automatically via GitHub Actions

--- a/src/components/google-tag-manager/index.tsx
+++ b/src/components/google-tag-manager/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import Script from 'next/script'
+import { analyticsConfig } from '@/lib/analytics.config'
 
-// Google Tag Manager ID
-const GTM_ID = 'GTM-TQ5H8HPR'
+// Google Tag Manager container ID. Edit it in src/lib/analytics.config.ts —
+// the single, easy-to-find place for all analytics IDs.
+const GTM_ID = analyticsConfig.gtmId
 
 export default function GoogleTagManager() {
   return (

--- a/src/lib/analytics.config.ts
+++ b/src/lib/analytics.config.ts
@@ -1,0 +1,25 @@
+// Analytics & tracking IDs — the single place to change them.
+//
+// These are NOT secrets. They are public, client-side identifiers that get
+// baked into the static export and are visible in the page source anyway. They
+// live here (rather than hardcoded inside components or read from environment
+// variables) so a forking charity — or an automated assistant — can point the
+// site at its own accounts by editing this one file.
+//
+// To use your own accounts, replace the placeholder values below with the IDs
+// from each provider's dashboard. Leave a value as its placeholder to keep that
+// integration effectively inert.
+export const analyticsConfig = {
+  // Google Tag Manager container ID, e.g. 'GTM-ABC1234'. GTM is the umbrella
+  // that can load the others, so this is the main one most sites set.
+  gtmId: 'GTM-TQ5H8HPR',
+
+  // Google Analytics 4 measurement ID, e.g. 'G-ABC1234567'.
+  gaMeasurementId: 'G-XXXXXXXXXX',
+
+  // Meta (Facebook) Pixel ID.
+  metaPixelId: 'XXXXXXXXXXXXXXX',
+
+  // Microsoft Clarity project ID.
+  clarityProjectId: 'XXXXXXXXXX',
+} as const

--- a/tests/test.config.ts
+++ b/tests/test.config.ts
@@ -11,6 +11,8 @@
  * 3. Maintain a single source of truth for test expectations
  */
 
+import { analyticsConfig } from '../src/lib/analytics.config'
+
 export const testConfig = {
   /**
    * Mission Video Configuration
@@ -100,9 +102,12 @@ export const testConfig = {
   /**
    * Google Tag Manager Configuration
    * Used in: tests/google-tag-manager.spec.ts
+   *
+   * Sourced from the same src/lib/analytics.config.ts the component reads, so
+   * the expected ID always matches what the build embedded.
    */
   googleTagManager: {
-    id: 'GTM-TQ5H8HPR',
+    id: analyticsConfig.gtmId,
   },
 
   /**


### PR DESCRIPTION
## Description

The Google Tag Manager container ID was hardcoded inside the GTM component, while GA / Clarity / Meta IDs were read from environment variables in `cookie-consent` — two different mechanisms, and GTM pointed at FFC's account so a fork would silently report to it.

These IDs are **not secrets** — they are public, client-side identifiers baked into the static export and visible in page source. So this consolidates all four into a single, plain, well-commented config file that a charity (or an AI assistant) can edit directly. Per maintainer guidance: not a GitHub Actions Variable, not buried in component code — just an easy-to-find file.

## Type of Change

- [x] New feature (configuration)
- [x] Code refactoring
- [x] Documentation update

## Changes Made

- **New `src/lib/analytics.config.ts`** exporting `analyticsConfig { gtmId, gaMeasurementId, metaPixelId, clarityProjectId }`. The committed `gtmId` stays the FFC container, so **production analytics keep working**; the others keep their existing placeholder values.
- `google-tag-manager` and `cookie-consent` now import from `analytics.config.ts` instead of a hardcoded constant / `process.env` reads.
- `tests/test.config.ts` sources the expected GTM id from the same file, so the E2E assertion always matches the build — one source of truth.
- Docs updated to describe the config file: `TEMPLATE_CUSTOMIZATION.md` ("Analytics & tracking IDs"), the GTM component `README.md`, and `EXTERNAL_DEPENDENCIES.md`.

## Review feedback addressed

This supersedes the earlier env-var/`.env.example` approach. It resolves all three Copilot comments — no `.env.example` GH-variable ambiguity, no stale "hardcoded GTM" docs (updated), and no Playwright env-loading mismatch (the test imports the config file directly).

## Testing Performed

- [x] `npm run lint` — passes (pre-existing `<img>` warnings only)
- [x] `npm test` — 91/91 unit tests pass
- [x] `npm run build` — static export succeeds with `GTM-TQ5H8HPR` embedded
- [x] `npm run check:drift` — no drift

## Breaking Changes

None — the committed `gtmId` preserves current production behavior. No env vars, no repository Variables, no deploy-workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)