### PR TITLE
refactor: move third-party integration IDs into siteConfig

### DIFF
--- a/src/components/home-page/Events/index.tsx
+++ b/src/components/home-page/Events/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { siteConfig } from '@/lib/site.config'
 
 const Events = () => {
   return (
@@ -17,7 +18,7 @@ const Events = () => {
         {/* SociableKit Facebook Events Widget */}
         <div className="flex justify-center">
           <iframe
-            src="https://widgets.sociablekit.com/facebook-page-events/iframe/25631700"
+            src={siteConfig.integrations.sociableKitEventsWidgetUrl}
             frameBorder={0}
             width="100%"
             height="1000"

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, IframeHTMLAttributes } from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
+import { siteConfig } from '@/lib/site.config'
 
 interface ExtendedIframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
   allowpaymentrequest?: string
@@ -22,7 +23,7 @@ const Index = () => {
   const donationFormProps: ExtendedIframeProps = {
     title: 'Donation form powered by Zeffy',
     style: donationFormStyle,
-    src: 'https://www.zeffy.com/embed/donation-form/free-for-charity-endowment-fund',
+    src: siteConfig.integrations.zeffyDonationUrl,
     allowpaymentrequest: '',
     allowtransparency: 'true',
   }

--- a/src/components/home-page/Volunteer-with-Us/index.tsx
+++ b/src/components/home-page/Volunteer-with-Us/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Image from 'next/image'
 import { assetPath } from '@/lib/assetPath'
+import { siteConfig } from '@/lib/site.config'
 
 const index = () => {
   return (
@@ -15,7 +16,7 @@ const index = () => {
           invaluable to our mission.
         </p>
         <a
-          href="https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities"
+          href={siteConfig.integrations.idealistUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="w-[216px] h-[62px] top-[261px] left-[611px] rounded-[27px] 

--- a/src/components/ui/ApplicationFormButton.tsx
+++ b/src/components/ui/ApplicationFormButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { siteConfig } from '@/lib/site.config'
 
 interface ApplicationFormButtonProps {
   text?: string
@@ -18,9 +19,10 @@ const ApplicationFormButton: React.FC<ApplicationFormButtonProps> = ({
   const modalRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
-  // Microsoft Form URL - using actual form from issue description
+  // Microsoft Form URL. Defaults to the configured form in siteConfig; callers
+  // can override per-instance via the `formUrl` prop.
   // Format: https://forms.office.com/r/{formId}
-  const microsoftFormUrl = formUrl || 'https://forms.office.com/r/vePxGq6JqG'
+  const microsoftFormUrl = formUrl || siteConfig.integrations.microsoftFormUrl
 
   const openPopup = useCallback(() => {
     setIsOpen(true)

--- a/src/lib/site.config.ts
+++ b/src/lib/site.config.ts
@@ -81,6 +81,21 @@ export type SiteConfig = {
    * nonprofit. Omit for a standalone charity (the footer clause is hidden).
    */
   parentOrg?: { name: string; url: string; hubUrl: string }
+  /**
+   * Third-party integration endpoints. Each fork points these at its own
+   * accounts — the domains are already allow-listed in the CSP, so only the
+   * path/ID changes here.
+   */
+  integrations: {
+    /** Zeffy donation-form embed URL (the iframe `src`). */
+    zeffyDonationUrl: string
+    /** Idealist volunteer-opportunities profile URL. */
+    idealistUrl: string
+    /** SociableKit Facebook-events widget iframe URL. */
+    sociableKitEventsWidgetUrl: string
+    /** Microsoft Forms application-form URL (https://forms.office.com/r/<id>). */
+    microsoftFormUrl: string
+  }
 }
 
 export const siteConfig: SiteConfig = {
@@ -135,6 +150,14 @@ export const siteConfig: SiteConfig = {
     name: 'Free For Charity',
     url: 'https://freeforcharity.org',
     hubUrl: 'https://freeforcharity.org/hub/',
+  },
+  integrations: {
+    zeffyDonationUrl: 'https://www.zeffy.com/embed/donation-form/free-for-charity-endowment-fund',
+    idealistUrl:
+      'https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities',
+    sociableKitEventsWidgetUrl:
+      'https://widgets.sociablekit.com/facebook-page-events/iframe/25631700',
+    microsoftFormUrl: 'https://forms.office.com/r/vePxGq6JqG',
   },
 }
 

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -39,11 +39,8 @@ test.describe('Events Section', () => {
     )
     await expect(eventsIframe).toBeVisible()
 
-    // Verify iframe has correct src
-    await expect(eventsIframe).toHaveAttribute(
-      'src',
-      'https://widgets.sociablekit.com/facebook-page-events/iframe/25631700'
-    )
+    // Verify iframe has correct src (sourced from siteConfig via test.config)
+    await expect(eventsIframe).toHaveAttribute('src', testConfig.events.widgetUrl)
 
     // Verify iframe has sandbox attribute for security
     const sandboxAttr = await eventsIframe.getAttribute('sandbox')

--- a/tests/test.config.ts
+++ b/tests/test.config.ts
@@ -47,6 +47,9 @@ export const testConfig = {
     facebookLinkText: 'View all events on Facebook',
     facebookUrl: 'https://www.facebook.com/freeforcharity',
     descriptionText: 'volunteer opportunities',
+    // Sourced from siteConfig so the expected iframe src always matches what the
+    // Events component renders (single source of truth).
+    widgetUrl: siteConfig.integrations.sociableKitEventsWidgetUrl,
   },
 
   /**


### PR DESCRIPTION
## Description

The Zeffy donation form, Idealist volunteer URL, SociableKit Facebook-events widget, and Microsoft Forms application form were **hardcoded in their components**, so a fork couldn't point the donate / volunteer / events / apply features at its own accounts without editing JSX. This moves all four into `siteConfig.integrations`, finishing the config-drive work started in #362.

## Type of Change

- [x] Code refactoring

## Changes Made

- Added a `siteConfig.integrations` object (`zeffyDonationUrl`, `idealistUrl`, `sociableKitEventsWidgetUrl`, `microsoftFormUrl`) to `src/lib/site.config.ts`.
- Rewired the four components to read from it: `SupportFreeForCharity` (Zeffy iframe), `Volunteer-with-Us` (Idealist link), `Events` (SociableKit iframe), and `ui/ApplicationFormButton` (Microsoft Forms — keeps its `formUrl` prop override, just sources the fallback from config).
- `tests/events.spec.ts` now asserts the iframe `src` against `siteConfig` (via `test.config`), matching the single-source-of-truth pattern used for the GTM id in #361.

## Testing Performed

- [x] `npm run lint` — passes (pre-existing `<img>` warnings only)
- [x] `npm test` — 102/102 unit tests pass
- [x] `npm run build` — static export succeeds; verified the Zeffy/Idealist/SociableKit `src`s render in `out/index.html`
- [x] `npm run check:drift` — no drift (the integration domains are unchanged, so the CSP needs no edits)

## Breaking Changes

None — domains unchanged; pure config extraction. Rebased on `main` after #362 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_