### PR TITLE
fix: render footer GuideStar seal with next/image

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import { FiMail, FiPhone, FiMapPin, FiArrowRight, FiLink2 } from 'react-icons/fi'
 import { FaFacebookF, FaLinkedinIn, FaGithub } from 'react-icons/fa'
 import { FaXTwitter } from 'react-icons/fa6'
@@ -38,9 +39,11 @@ const Footer: React.FC = () => {
               href={siteConfig.guidestar.profileUrl}
               aria-label={`View ${siteConfig.name} GuideStar Profile`}
             >
-              <img
+              <Image
                 src={assetPath('/Svgs/footerImage.svg')}
                 alt="GuideStar Platinum Seal of Transparency"
+                width={108}
+                height={108}
               />
             </a>
             <Link


### PR DESCRIPTION
## Description

The footer GuideStar transparency seal rendered as a raw `<img>` with no dimensions — the only *real*, fixable Lighthouse **`unsized-images`** Best-Practices flag, and the standing `@next/next/no-img-element` lint warning. This converts it to `next/image` with the SVG's intrinsic 108×108 dimensions.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Performance improvement (CLS / Best Practices)

## Changes Made

- `src/components/footer/index.tsx`: import `next/image`; render the seal via `<Image>` with explicit `width={108}` / `height={108}` (the SVG's `viewBox`/intrinsic size).

## Testing Performed

- [x] `npm run lint` — the footer `no-img-element` warning is **gone** (only the unrelated header `<img>` warning remains)
- [x] `npm test` — 102/102 unit tests pass
- [x] `npm run build` — static export succeeds; the seal still renders in `out/index.html`
- [x] `npm run check:drift` — no drift

## Breaking Changes

None — no visual change.

## Notes

Final PR of the config-drive batch (E #362, F #363, G). The rest of the flat "Best Practices 75%" cap is the LHCI `errors-in-console` HTTPS-probe artifact and the Next.js-required `unsafe-inline`/`unsafe-eval` CSP — neither is a fixable site bug, so this is the last actionable item there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_