### PR TITLE
fix: header logo via next/image and white-label footer policy labels

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -106,11 +106,11 @@ const Footer: React.FC = () => {
           </ul>
 
           <div className="space-y-3">
-            <h3 className="text-[28px] text-white">Free For Charity Policy</h3>
+            <h3 className="text-[28px] text-white">{siteConfig.name} Policy</h3>
             <ul className="space-y-1 text-sm lato-font">
               {[
                 {
-                  name: 'Free For Charity Donation Policy',
+                  name: `${siteConfig.name} Donation Policy`,
                   href: '/free-for-charity-donation-policy',
                 },
                 {
@@ -118,23 +118,23 @@ const Footer: React.FC = () => {
                   href: '/donation-policy',
                 },
                 {
-                  name: 'Free For Charity Privacy Policy',
+                  name: `${siteConfig.name} Privacy Policy`,
                   href: '/privacy-policy',
                 },
                 {
-                  name: 'Free For Charity Cookie Policy',
+                  name: `${siteConfig.name} Cookie Policy`,
                   href: '/cookie-policy',
                 },
                 {
-                  name: 'Free For Charity Terms of Service',
+                  name: `${siteConfig.name} Terms of Service`,
                   href: '/terms-of-service',
                 },
                 {
-                  name: 'Free For Charity Vulnerability Disclosure Policy',
+                  name: `${siteConfig.name} Vulnerability Disclosure Policy`,
                   href: '/vulnerability-disclosure-policy',
                 },
                 {
-                  name: 'Free For Charity Security Acknowledgement',
+                  name: `${siteConfig.name} Security Acknowledgement`,
                   href: '/security-acknowledgements',
                 },
               ].map((link) => (

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -2,11 +2,13 @@
 
 import React, { useState, useEffect, useMemo } from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
 import { FiMenu } from 'react-icons/fi'
 import { LiaSearchSolid } from 'react-icons/lia'
 import { RxCross2 } from 'react-icons/rx'
 import { motion, AnimatePresence } from 'framer-motion'
 import { assetPath } from '@/lib/assetPath'
+import { siteConfig } from '@/lib/site.config'
 
 interface MenuItem {
   label: string
@@ -98,11 +100,12 @@ const Header: React.FC = () => {
               className={`transition-all duration-300 ${isScrolled ? 'w-[110px]' : 'w-[150px]'}`}
             >
               <Link href="/" onClick={handleLinkClick} className="block">
-                <img
+                <Image
                   src={assetPath('/Images/logo.webp')}
-                  alt="Free For Charity"
+                  alt={siteConfig.name}
                   width={686}
                   height={234}
+                  priority
                   className={`w-auto max-w-none object-contain transition-all duration-300 ${
                     isScrolled ? 'h-7' : 'h-11'
                   }`}


### PR DESCRIPTION
## Description

Two small polish items that finish the lint cleanup and improve white-labeling.

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Code refactoring

## Changes Made

- **Header logo → `next/image`** (`src/components/header/index.tsx`): converts the last raw `<img>` — the only remaining `@next/next/no-img-element` warning — so **`npm run lint` is now 0 warnings**. Keeps the intrinsic 686×234 dimensions and the responsive container sizing (`w-auto` + `h-7`/`h-11`, so the aspect ratio is preserved and Next emits no ratio warning); adds `priority` since the logo is above the fold. Its `alt` now reads from `siteConfig.name`.
- **White-label footer policy labels** (`src/components/footer/index.tsx`): the six policy-link labels and the "Policy" heading hardcoded the "Free For Charity" prefix; they now interpolate `${siteConfig.name}`. Route `href`s are unchanged (the un-prefixed "Donation Policy" entry is intentionally left as-is).

## Testing Performed

- [x] `npm run lint` — **0 warnings** (header `<img>` gone)
- [x] `npm test` — 102/102 unit tests pass
- [x] `npm run build` — static export succeeds; logo + templated labels render in `out/index.html`
- [x] `npm run check:drift` — no drift

## Breaking Changes

None — no visual change for the FFC site (`siteConfig.name` is "Free For Charity").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_