### PR TITLE
docs: align onboarding docs with the config-driven template + integration setup

### DIFF
--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -13,9 +13,10 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
    - SEO description (1–2 sentences) and a shorter card description for OG / Twitter previews.
    - Production URL (custom domain) — if none yet, default to the GitHub Pages URL.
    - Twitter/X handle (optional), primary contact email, security disclosure email, primary social links (Facebook, X, LinkedIn, GitHub, others).
-   - EIN, mailing address(es), phone number(s) — the footer still hardcodes these.
+   - EIN, mailing address(es), phone number(s) — collected for `siteConfig` (`ein`, `phone`, `addresses`); these are no longer footer-hardcoded.
+   - GuideStar/Candid profile links, parent-organization details, and any third-party integration URLs (Zeffy, Idealist, SociableKit events, Microsoft Forms) — also collected for `siteConfig`.
 
-2. **Update `src/lib/site.config.ts`** with the values above. This is the canonical source — never duplicate. Helpers (`siteUrl`, `twitterSite`, `cardDescription`) drive layout/robots/sitemap/manifest/footer; do NOT change their signatures.
+2. **Update `src/lib/site.config.ts`** with the values above. This is the canonical source — never duplicate. It now drives the full per-charity value set: identity/SEO (`name`, `tagline`, `description`, `shortDescription`, `url`, `twitterHandle`, `keywords`, `themeColor`), `contactEmail`, `social`, AND `ein`, `phone`, `addresses`, `guidestar`, `parentOrg`, and `integrations`. Helpers (`siteUrl`, `twitterSite`, `cardDescription`) drive layout/robots/sitemap/manifest/footer; do NOT change their signatures. Analytics IDs (GTM / GA / Clarity / Meta Pixel) are set separately in `src/lib/analytics.config.ts`.
 
 3. **Update `public/CNAME`** if a custom domain is being used; otherwise delete it.
 
@@ -28,9 +29,7 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
 
 6. **Swap branded assets** in `public/Images/` and `public/Svgs/`. Keep filenames where possible so the LCP preload in `layout.tsx` and the manifest icons still hit real files.
 
-7. **Edit the footer** in `src/components/footer/index.tsx`:
-   - EIN, mailing addresses (Raleigh + State College), phone number, GuideStar profile URL, and the parent-organization link at the bottom are all hardcoded — replace with the charity's real info.
-   - The social-link rail and email already come from `siteConfig`; don't duplicate them.
+7. **Footer** — no per-charity CODE edits needed. EIN, addresses, phone, GuideStar links, parent-org link, social rail, and email all come from `siteConfig` (set in step 2). The only footer-related swap is the GuideStar / endorsement seal IMAGE asset in `public/Svgs/` if the charity's endorsements differ.
 
 8. **Replace content** in `src/data/` (testimonials, FAQs, team) and the home-page sections under `src/components/home-page/`.
 
@@ -73,7 +72,7 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
 
 ## Guardrails
 
-- Never paste API keys, GTM IDs, or secrets into committed files. Use GitHub Secrets / `.env` (gitignored).
+- Never commit real SECRETS, tokens, or passwords. Use GitHub Secrets / `.env` (gitignored). Note: the analytics IDs (GTM / GA / Clarity / Meta Pixel) are PUBLIC identifiers, not secrets — they live in `src/lib/analytics.config.ts` and committing them there is expected.
 - Never rename route folders to non-kebab-case (CI will fail).
 - Never bypass `assetPath()` for `/Images/`, `/Svgs/`, or `/videos/` references (CI will fail).
 - Never add a third-party origin (analytics, embed, payment) to only one of `public/_headers` or the CSP `<meta>` in `src/app/layout.tsx`. The drift checker enforces sync; one-sided changes will fail CI.

--- a/CONTENT_REPLACEMENT_GUIDE.md
+++ b/CONTENT_REPLACEMENT_GUIDE.md
@@ -348,15 +348,15 @@ The footer appears at the bottom of every page and contains important links and 
 
 ### Column 1 - Endorsements
 
-| Section | Variable                     | Current Free For Charity Content                                                | Your Content                                                        |
-| ------- | ---------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Footer  | Column 1 Heading             | "Endorsements"                                                                  | _(You might use "Certifications", "Verified By", or similar)_       |
-| Footer  | Endorsement Image 1          | `/Svgs/footerImage.svg` (GuideStar Platinum Seal)                               | _(Logo/seal image from your endorsing organizations)_               |
-| Footer  | Endorsement Image 1 Alt Text | "GuideStar Platinum Seal of Transparency"                                       |                                                                     |
-| Footer  | Endorsement Image 1 Link     | "https://www.guidestar.org/profile/46-2471893"                                  | _(Link to your profile page)_                                       |
-| Footer  | Direct Profile Link Text     | "Direct GuideStar Profile Link"                                                 | _(Or your equivalent verification link)_                            |
-| Footer  | Direct Profile Link URL      | "https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742" |                                                                     |
-| Footer  | EIN Display Text             | "Free For Charity EIN: 46-2471893"                                              | _(Your charity's EIN number, e.g., "Your Charity EIN: XX-XXXXXXX")_ |
+| Section | Variable                     | Current Free For Charity Content                                                                                                               | Your Content                                                        |
+| ------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Footer  | Column 1 Heading             | "Endorsements"                                                                                                                                 | _(You might use "Certifications", "Verified By", or similar)_       |
+| Footer  | Endorsement Image 1          | `/Svgs/footerImage.svg` (GuideStar Platinum Seal) — asset/markup in `src/components/footer/index.tsx`                                          | _(Logo/seal image from your endorsing organizations)_               |
+| Footer  | Endorsement Image 1 Alt Text | "GuideStar Platinum Seal of Transparency" — in `src/components/footer/index.tsx`                                                               |                                                                     |
+| Footer  | Endorsement Image 1 Link     | "https://www.guidestar.org/profile/46-2471893" — set `guidestar.profileUrl` in `src/lib/site.config.ts`                                        | _(Link to your profile page)_                                       |
+| Footer  | Direct Profile Link Text     | "Direct GuideStar Profile Link"                                                                                                                | _(Or your equivalent verification link)_                            |
+| Footer  | Direct Profile Link URL      | "https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742" — set `guidestar.directProfileUrl` in `src/lib/site.config.ts` |                                                                     |
+| Footer  | EIN Display Text             | "Free For Charity EIN: 46-2471893" — set `ein` in `src/lib/site.config.ts`                                                                     | _(Your charity's EIN number, e.g., "Your Charity EIN: XX-XXXXXXX")_ |
 
 ### Column 2 - Quick Links
 
@@ -406,27 +406,31 @@ _Note: These policy pages will need to be created with your charity's specific p
 
 ### Column 3 - Contact Information
 
+_Edit location: `src/lib/site.config.ts` — `contactEmail`, `phone.display` / `phone.tel`, and the `addresses[]` entries (`label`, `lines`, `mapUrl`). The footer renders these from siteConfig._
+
 | Section | Variable                           | Current Free For Charity Content                                                                    | Your Content                                         |
 | ------- | ---------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | Footer  | Column 3 Heading                   | "Contact Us"                                                                                        |                                                      |
 | Footer  | Email Label                        | "E-mail"                                                                                            |                                                      |
-| Footer  | Email Address                      | "clarkemoyer@freeforcharity.org"                                                                    | _(Your charity's contact email)_                     |
+| Footer  | Email Address (`contactEmail`)     | "clarkemoyer@freeforcharity.org"                                                                    | _(Your charity's contact email)_                     |
 | Footer  | Phone Label                        | "Call Us Today"                                                                                     |                                                      |
-| Footer  | Phone Number                       | "(520) 222-8104"                                                                                    | _(Your charity's phone number)_                      |
-| Footer  | Phone Number (dialable format)     | "5202228104"                                                                                        | _(Numbers only, no spaces or dashes)_                |
+| Footer  | Phone Number (`phone.display`)     | "(520) 222-8104"                                                                                    | _(Your charity's phone number)_                      |
+| Footer  | Phone Number (`phone.tel`)         | "5202228104"                                                                                        | _(Numbers only, no spaces or dashes)_                |
 | Footer  | Main Address Label                 | "Main Address"                                                                                      |                                                      |
 | Footer  | Main Address Line 1                | "4030 Wake Forrest Road"                                                                            |                                                      |
-| Footer  | Main Address Line 2                | "Suite 349 Raleigh North"                                                                           |                                                      |
-| Footer  | Main Address Line 3                | "Carolina 27609"                                                                                    |                                                      |
+| Footer  | Main Address Line 2                | "Suite 349"                                                                                         |                                                      |
+| Footer  | Main Address Line 3                | "Raleigh, NC 27609"                                                                                 |                                                      |
 | Footer  | Main Address Google Maps Link      | "https://www.google.com/maps/search/?api=1&query=4030+Wake+Forrest+Road+Suite+349+Raleigh+NC+27609" | _(Format: Google Maps search URL with your address)_ |
 | Footer  | Secondary Address Label            | "PA Office Address"                                                                                 | _(Optional second location)_                         |
-| Footer  | Secondary Address Line 1           | "301 Science Park Road Suite"                                                                       |                                                      |
-| Footer  | Secondary Address Line 2           | "119 State College PA 16803"                                                                        |                                                      |
+| Footer  | Secondary Address Line 1           | "301 Science Park Road, Suite 119"                                                                  |                                                      |
+| Footer  | Secondary Address Line 2           | "State College, PA 16803"                                                                           |                                                      |
 | Footer  | Secondary Address Google Maps Link | "https://www.google.com/maps/place/Free+For+Charity/@40.7768455,-77.8963305,17z/..."                |                                                      |
 
 _Note: If you don't have a second location, you can remove the secondary address section._
 
 ### Social Media Links
+
+_Edit location: `src/lib/site.config.ts` — the `social[]` array (each entry's `href`). The footer renders the rail from siteConfig._
 
 | Section | Variable              | Current Free For Charity Content                             | Your Content                                         |
 | ------- | --------------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
@@ -495,7 +499,7 @@ When implementing these changes:
 - **Programs section**: Edit `src/components/home-page/our-programs/index.tsx`
 - **FAQ section**: Edit `src/components/home-page/frequently-asked-questions/index.tsx`
 - **Team section**: Edit `src/components/home-page/the-free-for-charity-team/index.tsx`
-- **Footer**: Edit `src/components/footer/index.tsx`
+- **Footer**: The footer's per-charity values (EIN, phone, addresses, GuideStar links, social, email) come from `src/lib/site.config.ts`. Edit `src/components/footer/index.tsx` only for structural/markup changes (e.g. the endorsement seal image).
 - **Metadata**: Edit `src/app/layout.tsx`
 - **Navigation menu**: Edit `src/components/header/index.tsx`
 

--- a/EXTERNAL_DEPENDENCIES.md
+++ b/EXTERNAL_DEPENDENCIES.md
@@ -121,7 +121,7 @@ These are services we directly integrate into our application code.
 - **Data Collected:** Minimal (widget display only)
 - **Privacy Policy:** https://www.guidestar.org/privacy
 
-**Getting your own profile links:** Claim or look up your nonprofit's profile at https://www.guidestar.org (now Candid). Copy the public profile URL into `siteConfig.guidestar.profileUrl` and the shared-seal URL into `siteConfig.guidestar.directProfileUrl` in `src/lib/site.config.ts` (the `widgets.guidestar.org` domain is already allow-listed in the CSP).
+**Getting your own profile links:** Claim or look up your nonprofit's profile at https://www.guidestar.org (now Candid). Copy the public profile URL into `siteConfig.guidestar.profileUrl` and the shared-seal URL into `siteConfig.guidestar.directProfileUrl` in `src/lib/site.config.ts`. These are ordinary outbound links (to `www.guidestar.org`), so no CSP change is needed. The CSP already allow-lists the `widgets.guidestar.org` origin separately — that only matters if you later embed an interactive GuideStar/Candid widget rather than the static seal.
 
 ### External Volunteer Platforms
 

--- a/EXTERNAL_DEPENDENCIES.md
+++ b/EXTERNAL_DEPENDENCIES.md
@@ -81,6 +81,8 @@ These are services we directly integrate into our application code.
 - No Facebook SDK or direct Facebook domain requests are made; all event data is proxied through SociableKit
 - Privacy Considerations: Loading the widget may send user data (IP address, browser info, etc.) to SociableKit. Users should review SociableKit's privacy policy for details. Widget is only loaded after user consents to marketing cookies.
 
+**Getting your own widget URL:** Create a free account at https://www.sociablekit.com, add a "Facebook Page Events" widget for your charity's Facebook Page, and copy the iframe URL it generates. Set it in `siteConfig.integrations.sociableKitEventsWidgetUrl` in `src/lib/site.config.ts` (the `widgets.sociablekit.com` domain is already allow-listed in the CSP).
+
 ### Forms & User Input
 
 #### 6. Microsoft Forms
@@ -106,6 +108,8 @@ These are services we directly integrate into our application code.
 - **Data Collected:** Donation transaction data
 - **Privacy Policy:** https://support.zeffy.com/legal-data-privacy-security
 
+**Getting your own donation URL:** Sign up free at https://www.zeffy.com, create a donation form for your charity, then copy its embed/iframe URL. Set it in `siteConfig.integrations.zeffyDonationUrl` in `src/lib/site.config.ts` (the `www.zeffy.com` domain is already allow-listed in the CSP).
+
 ### Transparency & Validation
 
 #### 8. GuideStar (Candid)
@@ -117,6 +121,8 @@ These are services we directly integrate into our application code.
 - **Data Collected:** Minimal (widget display only)
 - **Privacy Policy:** https://www.guidestar.org/privacy
 
+**Getting your own profile links:** Claim or look up your nonprofit's profile at https://www.guidestar.org (now Candid). Copy the public profile URL into `siteConfig.guidestar.profileUrl` and the shared-seal URL into `siteConfig.guidestar.directProfileUrl` in `src/lib/site.config.ts` (the `widgets.guidestar.org` domain is already allow-listed in the CSP).
+
 ### External Volunteer Platforms
 
 #### 9. Idealist.org
@@ -126,6 +132,8 @@ These are services we directly integrate into our application code.
 - **URL:** `https://www.idealist.org/en/nonprofit/356bfc8e2ae64f83beea4a4e677e99d7-free-for-charity-state-college#opportunities`
 - **Data Collected:** None (external link only)
 - **Privacy Policy:** https://www.idealist.org/en/privacy
+
+**Getting your own profile URL:** Create your nonprofit's profile at https://www.idealist.org, then copy your volunteer-opportunities URL. Set it in `siteConfig.integrations.idealistUrl` in `src/lib/site.config.ts`.
 
 ## Transitive Dependencies
 

--- a/TEMPLATE_CUSTOMIZATION.md
+++ b/TEMPLATE_CUSTOMIZATION.md
@@ -27,10 +27,15 @@ charity's name, URL, contact email, social links, etc.
 | `themeColor`                  | Web manifest `theme_color` and `background_color`                                           |
 | `vulnerabilityDisclosurePath` | 404 page CTA, error page disclosure link                                                    |
 | `social`                      | Footer social-link rail (icon resolved by `label`: Facebook, X (Twitter), LinkedIn, GitHub) |
+| `ein`                         | Footer EIN display line                                                                     |
+| `phone`                       | Footer phone link (`phone.display` shown, `phone.tel` used for the `tel:` link)             |
+| `addresses`                   | Footer contact column (`addresses[].label` / `.lines` / `.mapUrl`)                          |
+| `guidestar`                   | Footer GuideStar/Candid seal links (`guidestar.profileUrl`, `guidestar.directProfileUrl`)   |
+| `parentOrg`                   | Footer "a project of" parent-org clause (omit for a standalone charity)                     |
+| `integrations`                | Zeffy donation embed, Idealist profile, SociableKit events widget, Microsoft Forms URL      |
 
-### Things `siteConfig` does NOT yet drive
+### Things `siteConfig` does NOT drive
 
-- **EIN, mailing addresses, phone numbers** — still hardcoded in `src/components/footer/index.tsx`. Add to siteConfig if your charity wants them.
 - **Hero/section copy** — lives in component files under `src/components/home-page/` and `src/data/`.
 - **GitHub Pages base path** — chosen automatically by `deploy.yml` and `lighthouse.yml` based on whether `public/CNAME` exists. With a CNAME the build uses an empty basePath (custom-domain root). Without a CNAME the build uses `/<repo-name>` for github.io subpath deploys. No manual workflow edit required when you rename the repo.
 - **OG/Twitter card image** — `layout.tsx` points at `/Images/og-image.png` (1200×630 landscape, the size social cards expect). To rebrand, replace `public/Images/og-image.png` with your own 1200×630 image (keep the filename). The square `/web-app-manifest-512x512.png` is still used separately for the PWA icon and the JSON-LD logo.
@@ -60,15 +65,15 @@ E2E tests assert against it, so there is a single source of truth.
 
 ## Files you'll likely touch when rebranding
 
-| File                                                            | What to change                                                                                                                                                                                                        |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `public/CNAME`                                                  | Custom domain (delete if using only github.io)                                                                                                                                                                        |
-| `public/.well-known/security.txt` **and** `public/security.txt` | `Contact`, `Canonical`, `Policy`, `Acknowledgments`, `Expires`. **Both copies must stay in sync** (the drift checker enforces it). The root copy exists because GitHub Pages does not serve dot-prefixed directories. |
-| `public/Images/*`, `public/Svgs/*`                              | Brand assets (keep filenames where possible)                                                                                                                                                                          |
-| `src/components/footer/index.tsx`                               | EIN, addresses, phone, GuideStar profile URLs, parent-org footer link — these are not in `siteConfig` (yet)                                                                                                           |
-| `src/data/*`                                                    | Testimonials, FAQs, team — your real content                                                                                                                                                                          |
-| `src/components/home-page/*`                                    | Home page sections                                                                                                                                                                                                    |
-| `src/app/privacy-policy/page.tsx` etc                           | Legal pages (have a lawyer review)                                                                                                                                                                                    |
+| File                                                            | What to change                                                                                                                                                                                                                           |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `public/CNAME`                                                  | Custom domain (delete if using only github.io)                                                                                                                                                                                           |
+| `public/.well-known/security.txt` **and** `public/security.txt` | `Contact`, `Canonical`, `Policy`, `Acknowledgments`, `Expires`. **Both copies must stay in sync** (the drift checker enforces it). The root copy exists because GitHub Pages does not serve dot-prefixed directories.                    |
+| `public/Images/*`, `public/Svgs/*`                              | Brand assets (keep filenames where possible)                                                                                                                                                                                             |
+| `src/components/footer/index.tsx`                               | Usually no edit needed — EIN, addresses, phone, GuideStar links, parent-org link, social rail, and email all read from `siteConfig`. Touch the footer code only to change the endorsement seal image/markup or other structural changes. |
+| `src/data/*`                                                    | Testimonials, FAQs, team — your real content                                                                                                                                                                                             |
+| `src/components/home-page/*`                                    | Home page sections                                                                                                                                                                                                                       |
+| `src/app/privacy-policy/page.tsx` etc                           | Legal pages (have a lawyer review)                                                                                                                                                                                                       |
 
 The web manifest is **auto-generated** from `siteConfig` at build time by `src/app/manifest.ts` — no separate file to edit.
 

--- a/TEMPLATE_SETUP_CHECKLIST.md
+++ b/TEMPLATE_SETUP_CHECKLIST.md
@@ -112,9 +112,10 @@ You don't have to edit either workflow when you rename the repo.
 - [ ] Run `npm run check:drift` after editing — the placeholder-URL
       and CSP-sync rules will flag anything still pointing at
       `ffcworkingsite1.org` or out of sync
-- [ ] Update the EIN, mailing addresses, phone number, and GuideStar
-      profile link still hardcoded in `src/components/footer/index.tsx`
-      (these are not in siteConfig yet)
+- [ ] Set the EIN, mailing addresses, phone number, and GuideStar
+      profile links in `src/lib/site.config.ts` — `ein`, `phone`,
+      `addresses`, and `guidestar.profileUrl` / `guidestar.directProfileUrl`.
+      The footer reads these from siteConfig; no footer code edit needed.
 
 ### Contact Information
 

--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -641,13 +641,13 @@ grep -r "46-2471893" . --exclude-dir=node_modules --exclude-dir=.git
 grep -r "ffcworkingsite1.org" . --exclude-dir=node_modules --exclude-dir=.git
 ```
 
-**Social media links**: Update in `src/components/footer/index.tsx`
+**Social media links**: Update `siteConfig.social` in `src/lib/site.config.ts`
 
 ### 2. Update Contact Information
 
 Files to update:
 
-- `src/components/footer/index.tsx` - Footer contact info
+- `src/lib/site.config.ts` - Footer contact info (`contactEmail`, `phone`, `addresses`, `ein`, `guidestar`) and `social` links
 - `SECURITY.md` - Security contact
 - `CODE_OF_CONDUCT.md` - Conduct reporting contact
 - `SUPPORT.md` - Support contact


### PR DESCRIPTION
## Description

Batches 1–2 (#356–#364) moved the charity's identity, contact, GuideStar links, integration URLs, and analytics IDs out of component JSX into `src/lib/site.config.ts` and `src/lib/analytics.config.ts`. But the **onboarding docs still told charities to edit the footer component** for those values — actively misdirecting a new fork. This makes the docs match reality and adds the integration setup guidance that was missing (combines the planned PR H + PR I — both docs).

## Type of Change

- [x] Documentation update

## Changes Made

**Docs accuracy (stop pointing at the footer component):**
- **`.claude/agents/onboarding.md`** — step 1 collects identity/integration values *for `siteConfig`*; step 2 lists the full `siteConfig` field set and points analytics IDs at `analytics.config.ts`; step 7 rewritten (footer needs no per-charity code edits — only the endorsement seal *image asset* may change); the guardrail no longer contradicts committing the public analytics IDs.
- **`TEMPLATE_CUSTOMIZATION.md`** — added `ein`/`phone`/`addresses`/`guidestar`/`parentOrg`/`integrations` rows to the siteConfig table; removed the false "does NOT yet drive … hardcoded in footer" bullet; fixed the "files you'll likely touch" footer row.
- **`TEMPLATE_SETUP_CHECKLIST.md`**, **`TEMPLATE_USAGE.md`**, **`CONTENT_REPLACEMENT_GUIDE.md`** — repoint EIN/phone/addresses/GuideStar/social/email guidance from the footer component to `siteConfig`; corrected the example address lines to match config.

**Integration setup guidance:**
- **`EXTERNAL_DEPENDENCIES.md`** — concise "getting your own ID" note for Zeffy, GuideStar/Candid, Idealist, and SociableKit, each with the signup URL and the `siteConfig` field that holds it.

## Testing Performed

- [x] `npm run check:drift` — clean
- [x] Grep confirms no remaining "edit the footer for EIN/phone/address/GuideStar" guidance (the one residual footer/logo reference is an asset note, out of scope)

## Breaking Changes

None — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_