### PR TITLE
feat: add WebSite JSON-LD and fix per-page canonical URLs

### DIFF
--- a/__tests__/components/seo/WebsiteSchema.test.tsx
+++ b/__tests__/components/seo/WebsiteSchema.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import WebsiteSchema, { buildWebsiteSchema } from '../../../src/components/seo/WebsiteSchema'
+import { siteConfig } from '../../../src/lib/site.config'
+
+describe('WebsiteSchema', () => {
+  it('builds a schema.org WebSite object with values from siteConfig', () => {
+    const schema = buildWebsiteSchema()
+
+    expect(schema['@context']).toBe('https://schema.org')
+    expect(schema['@type']).toBe('WebSite')
+    expect(schema.name).toBe(siteConfig.name)
+
+    expect(typeof schema.url).toBe('string')
+    expect(schema.url as string).toMatch(/^https:\/\//)
+
+    const publisher = schema.publisher as Record<string, unknown>
+    expect(publisher['@type']).toBe('NGO')
+    expect(publisher.name).toBe(siteConfig.name)
+  })
+
+  it('does not advertise a SearchAction (no site-search endpoint exists)', () => {
+    const schema = buildWebsiteSchema()
+    expect(schema.potentialAction).toBeUndefined()
+  })
+
+  it('renders a single application/ld+json script block whose JSON parses', () => {
+    const { container } = render(<WebsiteSchema />)
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]')
+    expect(scripts.length).toBe(1)
+    const text = scripts[0].textContent ?? ''
+    expect(text.length).toBeGreaterThan(0)
+    const parsed = JSON.parse(text) as Record<string, unknown>
+    expect(parsed['@type']).toBe('WebSite')
+    expect(parsed.name).toBe(siteConfig.name)
+  })
+})

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Cookie Policy | Free For Charity',
   description: 'Cookie Policy for Free For Charity website',
+  alternates: { canonical: '/cookie-policy' },
 }
 
 // Update this date when the policy changes

--- a/src/app/donation-policy/page.tsx
+++ b/src/app/donation-policy/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Donation Policy | Free For Charity',
   description: 'Donation Policy for Free For Charity website',
+  alternates: { canonical: '/donation-policy' },
 }
 
 export default function DonationPolicy() {

--- a/src/app/free-for-charity-donation-policy/page.tsx
+++ b/src/app/free-for-charity-donation-policy/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Free For Charity Donation Policy | Free For Charity',
   description: 'Free For Charity Donation Policy - Learn about our donation policies',
+  alternates: { canonical: '/free-for-charity-donation-policy' },
 }
 
 const index = () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,11 +2,13 @@ import React from 'react'
 import HomePage from '@/app/home-page'
 import OrganizationSchema from '@/components/seo/OrganizationSchema'
 import FaqSchema from '@/components/seo/FaqSchema'
+import WebsiteSchema from '@/components/seo/WebsiteSchema'
 
 const page = () => {
   return (
     <div>
       <OrganizationSchema />
+      <WebsiteSchema />
       <FaqSchema />
       <HomePage />
     </div>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Privacy Policy | Free For Charity',
   description: 'Privacy Policy for Free For Charity website',
+  alternates: { canonical: '/privacy-policy' },
 }
 
 export default function PrivacyPolicy() {

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Security Acknowledgements | Free For Charity',
   description: 'Security Acknowledgements for Free For Charity website',
+  alternates: { canonical: '/security-acknowledgements' },
 }
 
 const index = () => {

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Terms of Service | Free For Charity',
   description: 'Terms of Service for Free For Charity website',
+  alternates: { canonical: '/terms-of-service' },
 }
 
 export default function TermsOfService() {

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 export const metadata: Metadata = {
   title: 'Vulnerability Disclosure Policy | Free For Charity',
   description: 'Vulnerability Disclosure Policy for Free For Charity website',
+  alternates: { canonical: '/vulnerability-disclosure-policy' },
 }
 
 export default function VulnerabilityDisclosurePolicy() {

--- a/src/components/seo/WebsiteSchema.tsx
+++ b/src/components/seo/WebsiteSchema.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { siteConfig, siteUrl } from '@/lib/site.config'
+
+/**
+ * Builds the schema.org WebSite JSON-LD object for this site. Declaring the
+ * site's name + URL helps search engines render the correct site name in
+ * results and ties pages to a single site entity. Pulls values from
+ * `siteConfig` so a fork only edits one file. Exported separately so it can be
+ * asserted in unit tests without rendering.
+ *
+ * Note: no `potentialAction`/`SearchAction` is emitted because the template has
+ * no site-search results endpoint — advertising one would be invalid markup.
+ * Add a SearchAction here if/when a real `/search?q=` page exists.
+ */
+export function buildWebsiteSchema(): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: siteConfig.name,
+    url: siteUrl('/'),
+    description: siteConfig.description,
+    publisher: {
+      '@type': 'NGO',
+      name: siteConfig.name,
+    },
+  }
+}
+
+/**
+ * Emits a single <script type="application/ld+json"> block carrying a WebSite
+ * schema. Render once on the homepage beside the Organization and FAQ schemas.
+ *
+ * Server component — no client runtime cost.
+ */
+export default function WebsiteSchema() {
+  const schema = buildWebsiteSchema()
+  // Escape '<' as its JSON unicode form so a value containing "</script>"
+  // cannot break out of this inline script tag (JSON-LD injection guard).
+  const json = JSON.stringify(schema).replace(/</g, '\\u003c')
+  return (
+    <script
+      type="application/ld+json"
+      // dangerouslySetInnerHTML is the standard pattern for inline JSON-LD per
+      // the Next.js docs.
+      dangerouslySetInnerHTML={{ __html: json }}
+    />
+  )
+}


### PR DESCRIPTION
## Description

Two SEO improvements, one of which fixes a real bug.

## Type of Change

- [x] New feature (structured data)
- [x] Bug fix (canonical URLs)

## Changes Made

- **`WebSite` JSON-LD** — new `src/components/seo/WebsiteSchema.tsx` emits a `schema.org/WebSite` block (name, url, description, NGO publisher) on the home page beside the existing Organization and FAQ schemas, helping search engines render the correct site name. **No `SearchAction`** is emitted because the template has no site-search results endpoint — advertising one would be invalid markup (documented in the component). Mirrors the existing schema components (exported builder + `<`-escaped JSON-LD); unit-tested.
- **Per-page canonical fix** — the 7 legal pages set `title`/`description` but no `alternates.canonical`, so they inherited the root layout's `canonical: '/'` and each declared the **homepage** as its canonical (a duplicate-content bug). Added a self-referential `alternates.canonical` to each.

## Testing Performed

- [x] `npm run lint` — clean
- [x] `npm test` — 105/105 unit tests pass (3 new)
- [x] `npm run build` — static export succeeds; **verified** `out/index.html` has the `WebSite` JSON-LD and each `out/<legal>.html` now has a self-referential `<link rel="canonical">`
- [x] `npm run check:drift` — no drift

## Breaking Changes

None — additive schema + corrected canonicals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_