### PR TITLE
fix: footer nav landmarks + testimonials carousel a11y

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -74,80 +74,84 @@ const Footer: React.FC = () => {
         <div className="space-y-6 px-4 sm:px-0">
           <h2 className="text-[28px] text-white">Quick Links</h2>
 
-          <ul className="space-y-2 text-sm lato-font">
-            {[
-              { name: 'Home', href: '/#hero' },
-              { name: 'Mission', href: '/#mission' },
-              { name: 'Programs', href: '/#programs' },
-              { name: 'Events', href: '/#events' },
-              { name: 'Donate', href: '/#donate' },
-              { name: 'Volunteer', href: '/#volunteer' },
-              { name: 'FAQ', href: '/#faq' },
-              { name: 'Team', href: '/#team' },
-              // Only shown when this site is a project of a parent org with a hub.
-              ...(siteConfig.parentOrg?.hubUrl
-                ? [{ name: 'Supported Charity Login', href: siteConfig.parentOrg.hubUrl }]
-                : []),
-            ].map((link) => {
-              const isExternal = link.href.startsWith('http')
-              return (
-                <li key={link.name}>
-                  <Link
-                    href={link.href}
-                    target={isExternal ? '_blank' : undefined}
-                    rel={isExternal ? 'noopener noreferrer' : undefined}
-                    className="hover:text-[#F58C23] hover:tracking-widest transition-all text-[16px] font-[500]"
-                  >
-                    {link.name}
-                  </Link>
-                </li>
-              )
-            })}
-          </ul>
+          <nav aria-label="Quick links">
+            <ul className="space-y-2 text-sm lato-font">
+              {[
+                { name: 'Home', href: '/#hero' },
+                { name: 'Mission', href: '/#mission' },
+                { name: 'Programs', href: '/#programs' },
+                { name: 'Events', href: '/#events' },
+                { name: 'Donate', href: '/#donate' },
+                { name: 'Volunteer', href: '/#volunteer' },
+                { name: 'FAQ', href: '/#faq' },
+                { name: 'Team', href: '/#team' },
+                // Only shown when this site is a project of a parent org with a hub.
+                ...(siteConfig.parentOrg?.hubUrl
+                  ? [{ name: 'Supported Charity Login', href: siteConfig.parentOrg.hubUrl }]
+                  : []),
+              ].map((link) => {
+                const isExternal = link.href.startsWith('http')
+                return (
+                  <li key={link.name}>
+                    <Link
+                      href={link.href}
+                      target={isExternal ? '_blank' : undefined}
+                      rel={isExternal ? 'noopener noreferrer' : undefined}
+                      className="hover:text-[#F58C23] hover:tracking-widest transition-all text-[16px] font-[500]"
+                    >
+                      {link.name}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
 
           <div className="space-y-3">
             <h3 className="text-[28px] text-white">{siteConfig.name} Policy</h3>
-            <ul className="space-y-1 text-sm lato-font">
-              {[
-                {
-                  name: `${siteConfig.name} Donation Policy`,
-                  href: '/free-for-charity-donation-policy',
-                },
-                {
-                  name: 'Donation Policy',
-                  href: '/donation-policy',
-                },
-                {
-                  name: `${siteConfig.name} Privacy Policy`,
-                  href: '/privacy-policy',
-                },
-                {
-                  name: `${siteConfig.name} Cookie Policy`,
-                  href: '/cookie-policy',
-                },
-                {
-                  name: `${siteConfig.name} Terms of Service`,
-                  href: '/terms-of-service',
-                },
-                {
-                  name: `${siteConfig.name} Vulnerability Disclosure Policy`,
-                  href: '/vulnerability-disclosure-policy',
-                },
-                {
-                  name: `${siteConfig.name} Security Acknowledgement`,
-                  href: '/security-acknowledgements',
-                },
-              ].map((link) => (
-                <li key={link.name}>
-                  <Link
-                    href={link.href}
-                    className="hover:text-[#F58C23] hover:tracking-widest transition-all text-[16px] font-[500]"
-                  >
-                    {link.name}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+            <nav aria-label="Policy links">
+              <ul className="space-y-1 text-sm lato-font">
+                {[
+                  {
+                    name: `${siteConfig.name} Donation Policy`,
+                    href: '/free-for-charity-donation-policy',
+                  },
+                  {
+                    name: 'Donation Policy',
+                    href: '/donation-policy',
+                  },
+                  {
+                    name: `${siteConfig.name} Privacy Policy`,
+                    href: '/privacy-policy',
+                  },
+                  {
+                    name: `${siteConfig.name} Cookie Policy`,
+                    href: '/cookie-policy',
+                  },
+                  {
+                    name: `${siteConfig.name} Terms of Service`,
+                    href: '/terms-of-service',
+                  },
+                  {
+                    name: `${siteConfig.name} Vulnerability Disclosure Policy`,
+                    href: '/vulnerability-disclosure-policy',
+                  },
+                  {
+                    name: `${siteConfig.name} Security Acknowledgement`,
+                    href: '/security-acknowledgements',
+                  },
+                ].map((link) => (
+                  <li key={link.name}>
+                    <Link
+                      href={link.href}
+                      className="hover:text-[#F58C23] hover:tracking-widest transition-all text-[16px] font-[500]"
+                    >
+                      {link.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
           </div>
         </div>
 

--- a/src/components/home-page/Testimonials/index.tsx
+++ b/src/components/home-page/Testimonials/index.tsx
@@ -48,7 +48,17 @@ const TestimonialSlider: React.FC = () => {
       <div className="container mx-auto px-4 max-w-[1150px] text-center">
         <h2 className="font-bold text-[#E16820] text-[40px] leading-[44px] mb-7">Testimonials</h2>
 
-        <div className="relative">
+        {/* Carousel landmark so assistive tech announces this region and its
+            role. aria-live is intentionally omitted: the carousel auto-rotates,
+            and a live region on an auto-rotating carousel would announce every
+            transition (ARIA APG guidance). The prev/next/dot controls already
+            carry descriptive aria-labels. */}
+        <div
+          className="relative"
+          role="region"
+          aria-roledescription="carousel"
+          aria-label="Testimonials"
+        >
           <Swiper
             modules={[Navigation, Autoplay]}
             onSwiper={setSwiperInstance}


### PR DESCRIPTION
## Description

Accessibility polish (markup only, no behavior change).

## Type of Change

- [x] Bug fix (accessibility)

## Changes Made

- **Footer nav landmarks** — wrapped the Quick Links and Policy link lists each in a labeled `<nav>` (`"Quick links"` / `"Policy links"`). The `<footer>` landmark already existed; this adds distinct navigation regions so screen-reader users can jump between the link groups.
- **Testimonials carousel** — marked the carousel container `role="region"` with `aria-roledescription="carousel"` + `aria-label="Testimonials"` so assistive tech announces the region and its role. **`aria-live` is intentionally omitted** because the carousel auto-rotates — a live region there is an ARIA APG anti-pattern that would announce every 5s transition. The prev/next/dot controls already carry descriptive `aria-label`s.

## Testing Performed

- [x] `npm run lint` — clean
- [x] `npm test` — 102/102 unit tests pass (incl. the footer `jest-axe` test)
- [x] `npm run build` — static export succeeds; landmarks verified in `out/index.html`
- [x] `npm run check:drift` — no drift

## Breaking Changes

None — semantic markup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_