### PR TITLE
feat: add rebrand-check script for forking charities

### DIFF
--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -49,13 +49,16 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
     npm install
     npm run format
     npm run lint
-    npm run check:drift   # MUST be 0 errors; warnings should not increase
+    npm run check:drift     # MUST be 0 errors; warnings should not increase
+    npm run check:rebrand   # checklist of FFC defaults still present (guide only)
     npm test
     npm run build
     npm run test:e2e
     ```
 
-    Fix anything red before opening a PR.
+    Fix anything red before opening a PR. `check:rebrand` never fails the build —
+    treat its checklist as the "did I replace every FFC default?" confirmation
+    (charity name, EIN, phone, email, domain, GTM container, sample content).
 
 13. **Open a PR titled** `chore: initial customization for <Charity Name>` linking the onboarding issue. In the body include:
     - A checklist of every file edited

--- a/TEMPLATE_CUSTOMIZATION.md
+++ b/TEMPLATE_CUSTOMIZATION.md
@@ -43,6 +43,20 @@ charity's name, URL, contact email, social links, etc.
 After editing, **run `npm run check:drift`** to confirm nothing else still
 references the old placeholder values.
 
+### Are you done rebranding? — `npm run check:rebrand`
+
+Run **`npm run check:rebrand`** at any point to get a checklist of every value
+that still matches the Free For Charity template defaults — charity name, EIN,
+phone, contact email, domain/CNAME, the GTM analytics container, and the sample
+team / testimonials / FAQ content. It is a guide, not a gate: it always exits 0
+on the template itself (the canonical repo intentionally keeps FFC's values), so
+it never blocks a PR. If your fork wants to _enforce_ "fully rebranded before
+deploy", wire `node scripts/rebrand-check.mjs --strict` (which exits non-zero
+while any default remains) into your own CI.
+
+> Note: leaving the GTM container as `GTM-TQ5H8HPR` sends your site's analytics
+> to Free For Charity — replace it in `src/lib/analytics.config.ts` early.
+
 ## Analytics & tracking IDs
 
 All analytics identifiers live in one file:
@@ -115,6 +129,7 @@ GitHub Pages, or vice versa.
 npm run format         # auto-fix formatting
 npm run lint           # ESLint
 npm run check:drift    # FFC best-practices
+npm run check:rebrand  # remaining template defaults (guide only, never fails)
 npm test               # Jest unit tests
 npm run build          # static export
 npm run test:e2e       # Playwright

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "check:drift": "node scripts/check-drift.mjs",
+    "check:rebrand": "node scripts/rebrand-check.mjs",
     "smoke": "node scripts/smoke-check.mjs",
     "audit:high": "npm audit --omit=dev --audit-level=high",
     "prepare": "husky"

--- a/scripts/rebrand-check.mjs
+++ b/scripts/rebrand-check.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * FFC rebrand checklist — a guide for a charity that just forked the template.
+ *
+ * It reports every value that still matches the template's Free For Charity
+ * defaults, grouped by category, so a fork knows exactly what to change to make
+ * the site its own. Unlike `check-drift.mjs`, this is NOT a CI gate on the
+ * template repo: the canonical template intentionally keeps FFC's real values,
+ * so a gating check would fail every PR here. It therefore exits 0 by default.
+ *
+ * A fork that wants to enforce "fully rebranded before deploy" can run it with
+ * `--strict`, which exits non-zero while any template default remains.
+ *
+ *   node scripts/rebrand-check.mjs            # report only, exit 0
+ *   node scripts/rebrand-check.mjs --strict   # exit 1 if anything is unchanged
+ *   npm run check:rebrand                     # same as the first form
+ *
+ * Always resolves paths relative to the repo root, so it works regardless of
+ * the CWD a developer invokes it from.
+ */
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(SCRIPT_DIR, '..')
+const STRICT = process.argv.includes('--strict')
+
+// Recursively collect files under `dir` whose basename passes `predicate`.
+// Skips node_modules and dot-directories, mirroring scripts/check-drift.mjs.
+async function walk(dir, predicate, results = []) {
+  let entries
+  try {
+    entries = await readdir(dir, { withFileTypes: true })
+  } catch {
+    return results
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+      await walk(full, predicate, results)
+    } else if (predicate(entry.name)) {
+      results.push(full)
+    }
+  }
+  return results
+}
+
+async function readText(rel) {
+  try {
+    return await readFile(join(ROOT, rel), 'utf8')
+  } catch {
+    return null
+  }
+}
+
+// True if any file under `relDir` contains `needle`.
+async function dirContains(relDir, needle) {
+  const files = await walk(join(ROOT, relDir), (n) => n.endsWith('.json'))
+  for (const file of files) {
+    const body = await readFile(file, 'utf8')
+    if (body.includes(needle)) return true
+  }
+  return false
+}
+
+// Each finding: a template default still present that a fork should replace.
+const findings = []
+function flag(category, label, where) {
+  findings.push({ category, label, where })
+}
+
+// --- Organization identity (src/lib/site.config.ts) ---------------------------
+// These are the FFC values a fork must replace with its own. We look for each
+// default string in the config file; substring presence is the right signal
+// for a "did you change this yet?" checklist (mirrors check-drift's approach).
+async function checkSiteConfig() {
+  const rel = 'src/lib/site.config.ts'
+  const cfg = await readText(rel)
+  if (cfg === null) {
+    flag('Organization identity', `${rel} is missing — restore it from the template`, rel)
+    return
+  }
+  const defaults = [
+    ['Charity name still "Free For Charity"', 'Free For Charity'],
+    ['Domain still ffcworkingsite1.org', 'ffcworkingsite1.org'],
+    ['EIN (tax ID) still 46-2471893', '46-2471893'],
+    ['Phone still (520) 222-8104', '5202228104'],
+    ['Contact email still security@freeforcharity.org', 'security@freeforcharity.org'],
+    ['Twitter/X handle still @freeforcharity', 'freeforcharity'],
+    ['Mailing address still FFC (Wake Forrest Road)', 'Wake Forrest Road'],
+  ]
+  for (const [label, needle] of defaults) {
+    if (cfg.includes(needle)) flag('Organization identity', label, rel)
+  }
+}
+
+// --- Analytics (src/lib/analytics.config.ts) ----------------------------------
+// The GA/Pixel/Clarity values ship as inert "XXXX" placeholders, so leaving
+// them is harmless. The GTM container ID, however, is FFC's REAL container —
+// leaving it sends the fork's analytics to Free For Charity. Flag it loudly.
+async function checkAnalyticsConfig() {
+  const rel = 'src/lib/analytics.config.ts'
+  const cfg = await readText(rel)
+  if (cfg === null) return
+  if (cfg.includes('GTM-TQ5H8HPR')) {
+    flag(
+      'Analytics',
+      'GTM container still GTM-TQ5H8HPR (FFC’s own) — your analytics will flow to FFC',
+      rel
+    )
+  }
+}
+
+// --- Deployment files ---------------------------------------------------------
+async function checkDeployment() {
+  const cname = await readText('public/CNAME')
+  if (cname && cname.includes('ffcworkingsite1.org')) {
+    flag('Deployment', 'public/CNAME still points at ffcworkingsite1.org', 'public/CNAME')
+  }
+  const securityTxt = await readText('public/security.txt')
+  if (securityTxt && securityTxt.includes('freeforcharity')) {
+    flag(
+      'Deployment',
+      'public/security.txt Contact still references freeforcharity (keep in sync with .well-known/)',
+      'public/security.txt'
+    )
+  }
+}
+
+// --- Sample content -----------------------------------------------------------
+// Flag the demo data if the recognizable FFC sample entries are untouched.
+async function checkSampleContent() {
+  if (await dirContains('src/data/team', 'Clarke Moyer')) {
+    flag('Sample content', 'Team still shows the FFC sample members', 'src/data/team/*.json')
+  }
+  if (await dirContains('src/data/testimonials', 'American Legion Ahwatukee')) {
+    flag(
+      'Sample content',
+      'Testimonials still show the FFC samples',
+      'src/data/testimonials/*.json'
+    )
+  }
+  if (await dirContains('src/data/faqs', 'Are you really a Charity')) {
+    flag('Sample content', 'FAQ still shows the FFC sample questions', 'src/data/faqs/*.json')
+  }
+}
+
+await checkSiteConfig()
+await checkAnalyticsConfig()
+await checkDeployment()
+await checkSampleContent()
+
+if (findings.length === 0) {
+  console.log('\n✅ Rebrand complete — no Free For Charity template defaults detected.')
+  process.exit(0)
+}
+
+// Group findings by category for a readable checklist.
+const byCategory = new Map()
+for (const f of findings) {
+  if (!byCategory.has(f.category)) byCategory.set(f.category, [])
+  byCategory.get(f.category).push(f)
+}
+
+console.log('\n📋 Rebrand checklist — values still matching the Free For Charity template:\n')
+for (const [category, items] of byCategory) {
+  console.log(`  ${category}:`)
+  for (const item of items) {
+    console.log(`    ☐ ${item.label}`)
+    console.log(`        → edit ${item.where}`)
+  }
+  console.log('')
+}
+const n = findings.length
+console.log(
+  `${n} template default${n === 1 ? '' : 's'} still present. ` +
+    'Update them to make this site your own. See TEMPLATE_CUSTOMIZATION.md.'
+)
+
+if (STRICT) {
+  console.error('\n❌ --strict: failing because template defaults remain.')
+  process.exit(1)
+}
+process.exit(0)

--- a/scripts/rebrand-check.mjs
+++ b/scripts/rebrand-check.mjs
@@ -122,25 +122,33 @@ async function checkDeployment() {
   if (cname && cname.includes('ffcworkingsite1.org')) {
     flag('Deployment', 'public/CNAME still points at ffcworkingsite1.org', 'public/CNAME')
   }
+  // The site ships TWO security.txt copies (root + .well-known/) that must stay
+  // in sync. Scan both so a fork that updated only one copy is still flagged.
   // Check the Contact email and the Canonical/Policy URLs separately — a fork
-  // might update one and forget the other. Both copies of the file must stay in
-  // sync (the drift checker enforces that), so flagging the root copy is enough.
-  const securityTxt = await readText('public/security.txt')
-  if (securityTxt) {
-    if (securityTxt.includes('security@freeforcharity.org')) {
-      flag(
-        'Deployment',
-        'public/security.txt Contact still security@freeforcharity.org (keep in sync with .well-known/)',
-        'public/security.txt'
-      )
-    }
-    if (securityTxt.includes('ffcworkingsite1.org')) {
-      flag(
-        'Deployment',
-        'public/security.txt Canonical/Policy URLs still point at ffcworkingsite1.org',
-        'public/security.txt'
-      )
-    }
+  // might update one and forget the other.
+  const securityFiles = ['public/security.txt', 'public/.well-known/security.txt']
+  const bodies = []
+  for (const rel of securityFiles) {
+    const body = await readText(rel)
+    if (body !== null) bodies.push([rel, body])
+  }
+  const filesWith = (needle) => bodies.filter(([, b]) => b.includes(needle)).map(([rel]) => rel)
+
+  const withEmail = filesWith('security@freeforcharity.org')
+  if (withEmail.length) {
+    flag(
+      'Deployment',
+      `security.txt Contact still security@freeforcharity.org`,
+      withEmail.join(', ')
+    )
+  }
+  const withUrl = filesWith('ffcworkingsite1.org')
+  if (withUrl.length) {
+    flag(
+      'Deployment',
+      'security.txt Canonical/Policy URLs still point at ffcworkingsite1.org',
+      withUrl.join(', ')
+    )
   }
 }
 

--- a/scripts/rebrand-check.mjs
+++ b/scripts/rebrand-check.mjs
@@ -88,7 +88,10 @@ async function checkSiteConfig() {
     ['EIN (tax ID) still 46-2471893', '46-2471893'],
     ['Phone still (520) 222-8104', '5202228104'],
     ['Contact email still security@freeforcharity.org', 'security@freeforcharity.org'],
-    ['Twitter/X handle still @freeforcharity', 'freeforcharity'],
+    // Match the twitterHandle assignment specifically — a bare "freeforcharity"
+    // needle also hits the email and the Facebook/LinkedIn/GitHub social URLs,
+    // so it would mis-fire even after a fork updated the handle.
+    ['Twitter/X handle still @freeforcharity', "twitterHandle: '@freeforcharity'"],
     ['Mailing address still FFC (Wake Forrest Road)', 'Wake Forrest Road'],
   ]
   for (const [label, needle] of defaults) {
@@ -119,13 +122,25 @@ async function checkDeployment() {
   if (cname && cname.includes('ffcworkingsite1.org')) {
     flag('Deployment', 'public/CNAME still points at ffcworkingsite1.org', 'public/CNAME')
   }
+  // Check the Contact email and the Canonical/Policy URLs separately — a fork
+  // might update one and forget the other. Both copies of the file must stay in
+  // sync (the drift checker enforces that), so flagging the root copy is enough.
   const securityTxt = await readText('public/security.txt')
-  if (securityTxt && securityTxt.includes('freeforcharity')) {
-    flag(
-      'Deployment',
-      'public/security.txt Contact still references freeforcharity (keep in sync with .well-known/)',
-      'public/security.txt'
-    )
+  if (securityTxt) {
+    if (securityTxt.includes('security@freeforcharity.org')) {
+      flag(
+        'Deployment',
+        'public/security.txt Contact still security@freeforcharity.org (keep in sync with .well-known/)',
+        'public/security.txt'
+      )
+    }
+    if (securityTxt.includes('ffcworkingsite1.org')) {
+      flag(
+        'Deployment',
+        'public/security.txt Canonical/Policy URLs still point at ffcworkingsite1.org',
+        'public/security.txt'
+      )
+    }
   }
 }
 

--- a/scripts/rebrand-check.mjs
+++ b/scripts/rebrand-check.mjs
@@ -19,7 +19,7 @@
  * the CWD a developer invokes it from.
  */
 import { readdir, readFile } from 'node:fs/promises'
-import { dirname, join, relative } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))


### PR DESCRIPTION
## Description

Adds `scripts/rebrand-check.mjs` + `npm run check:rebrand` — a guide that helps a
nonprofit forking this template see exactly which values still match the Free For
Charity defaults, so nothing gets missed when they make the site their own.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **`scripts/rebrand-check.mjs`** (mirrors the `check-drift.mjs` house style): prints a grouped checklist of template defaults still present, across four categories:
  - **Organization identity** (`src/lib/site.config.ts`): charity name, domain, EIN, phone, contact email, Twitter handle, mailing address
  - **Analytics** (`src/lib/analytics.config.ts`): the GTM container `GTM-TQ5H8HPR` — flagged loudly because leaving it sends the fork's analytics to FFC
  - **Deployment**: `public/CNAME`, `public/security.txt`
  - **Sample content**: `src/data/team`, `src/data/testimonials`, `src/data/faqs`
- **Guide, not a gate**: exits 0 by default (the canonical template intentionally keeps FFC's values, so a gating check would fail every PR here). A fork can run `node scripts/rebrand-check.mjs --strict` to fail while any default remains and wire that into its own CI.
- **`package.json`**: adds `"check:rebrand": "node scripts/rebrand-check.mjs"`.
- **Docs**: documented in `TEMPLATE_CUSTOMIZATION.md` (with a GTM warning) and added to the `onboarding` agent's pre-commit gauntlet.

## Related Issue(s)

Refs the template-quality improvement batch (Batch 5).

## Testing Performed

### Automated Testing

- [x] `npm run lint` — 0 warnings
- [x] `npm test` — 105/105 unit tests pass
- [x] `npm run build` — static export succeeds
- [x] `npm run check:drift` — no drift
- [x] `npm run check:rebrand` — lists FFC defaults, exits 0; `--strict` exits 1

## Breaking Changes

None / N/A — new read-only script, not wired into the template repo's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_