### PR TITLE
test: raise jest coverage floor from 5% to current levels

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,12 +20,16 @@ const customJestConfig = {
     '!**/node_modules/**',
     '!src/app/layout.tsx', // Exclude layout due to font imports causing issues
   ],
+  // Coverage floors set a few points below the current measured coverage
+  // (branches ~47%, functions ~59%, lines/statements ~60%) so a real
+  // regression fails CI, while leaving enough margin that a trivial diff
+  // adding one uncovered branch doesn't. Raise these as coverage improves.
   coverageThreshold: {
     global: {
-      branches: 5,
-      functions: 5,
-      lines: 5,
-      statements: 5,
+      branches: 40,
+      functions: 50,
+      lines: 50,
+      statements: 50,
     },
   },
   moduleNameMapper: {


### PR DESCRIPTION
## Description

The jest `coverageThreshold.global` floors were all set to **5%** — a placeholder that
would let coverage silently collapse without failing CI. This raises them to just below
the **currently measured** coverage so a real regression fails, without forcing any new tests.

## Type of Change

- [x] Test addition/update

## Changes Made

- Measured current global coverage via `npm run test:coverage`: **statements 60.3%, branches 47.4%, functions 58.8%, lines 60.6%**.
- Raised `jest.config.js` `coverageThreshold.global` from `5/5/5/5` to **branches 40, functions 50, lines 50, statements 50** — a few points below measured, so a genuine regression trips the gate while a trivial diff that adds one uncovered branch does not.
- Added a comment documenting the rationale and inviting future increases as coverage improves.
- No test or source changes.

## Related Issue(s)

Refs the template-quality improvement batch (Batch 5).

## Testing Performed

### Automated Testing

- [x] `npm run test:coverage` — 105/105 pass at the new floors
- [x] `npm test` — green

## Breaking Changes

None / N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_