### PR TITLE
feat: add BreadcrumbList JSON-LD to legal sub-pages

### DIFF
--- a/__tests__/components/seo/BreadcrumbSchema.test.tsx
+++ b/__tests__/components/seo/BreadcrumbSchema.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import BreadcrumbSchema, {
+  buildBreadcrumbSchema,
+} from '../../../src/components/seo/BreadcrumbSchema'
+import { siteUrl } from '../../../src/lib/site.config'
+
+describe('BreadcrumbSchema', () => {
+  it('builds a two-item BreadcrumbList from Home to the page', () => {
+    const schema = buildBreadcrumbSchema('Privacy Policy', '/privacy-policy')
+
+    expect(schema['@context']).toBe('https://schema.org')
+    expect(schema['@type']).toBe('BreadcrumbList')
+
+    const items = schema.itemListElement as Array<Record<string, unknown>>
+    expect(items).toHaveLength(2)
+
+    expect(items[0]).toMatchObject({
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: siteUrl('/'),
+    })
+    expect(items[1]).toMatchObject({
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Privacy Policy',
+      item: siteUrl('/privacy-policy'),
+    })
+  })
+
+  it('uses absolute https URLs for every crumb', () => {
+    const schema = buildBreadcrumbSchema('Terms of Service', '/terms-of-service')
+    const items = schema.itemListElement as Array<Record<string, unknown>>
+    for (const item of items) {
+      expect(item.item as string).toMatch(/^https:\/\//)
+    }
+  })
+
+  it('renders a single application/ld+json script block whose JSON parses', () => {
+    const { container } = render(<BreadcrumbSchema name="Cookie Policy" path="/cookie-policy" />)
+    const scripts = container.querySelectorAll('script[type="application/ld+json"]')
+    expect(scripts.length).toBe(1)
+    const text = scripts[0].textContent ?? ''
+    const parsed = JSON.parse(text) as Record<string, unknown>
+    expect(parsed['@type']).toBe('BreadcrumbList')
+    const items = parsed.itemListElement as Array<Record<string, unknown>>
+    expect(items[1].name).toBe('Cookie Policy')
+  })
+})

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from 'next'
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
+const PAGE_NAME = 'Cookie Policy'
+const CANONICAL_PATH = '/cookie-policy'
+
 export const metadata: Metadata = {
-  title: 'Cookie Policy | Free For Charity',
+  title: `${PAGE_NAME} | Free For Charity`,
   description: 'Cookie Policy for Free For Charity website',
-  alternates: { canonical: '/cookie-policy' },
+  alternates: { canonical: CANONICAL_PATH },
 }
 
 // Update this date when the policy changes
@@ -13,7 +16,7 @@ const LAST_UPDATED = 'December 7, 2025'
 export default function CookiePolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
-      <BreadcrumbSchema name="Cookie Policy" path="/cookie-policy" />
+      <BreadcrumbSchema name={PAGE_NAME} path={CANONICAL_PATH} />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -5,7 +5,9 @@ const PAGE_NAME = 'Cookie Policy'
 const CANONICAL_PATH = '/cookie-policy'
 
 export const metadata: Metadata = {
-  title: `${PAGE_NAME} | Free For Charity`,
+  // The root layout's title template appends " | Free For Charity", so the
+  // page title is just the page name (avoids a doubled brand suffix).
+  title: PAGE_NAME,
   description: 'Cookie Policy for Free For Charity website',
   alternates: { canonical: CANONICAL_PATH },
 }

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
 export const metadata: Metadata = {
   title: 'Cookie Policy | Free For Charity',
@@ -12,6 +13,7 @@ const LAST_UPDATED = 'December 7, 2025'
 export default function CookiePolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
+      <BreadcrumbSchema name="Cookie Policy" path="/cookie-policy" />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[1em] font-[500]">

--- a/src/app/donation-policy/page.tsx
+++ b/src/app/donation-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
 export const metadata: Metadata = {
   title: 'Donation Policy | Free For Charity',
@@ -9,6 +10,7 @@ export const metadata: Metadata = {
 export default function DonationPolicy() {
   return (
     <div className="ffc-container py-16">
+      <BreadcrumbSchema name="Donation Policy" path="/donation-policy" />
       <div className="max-w-4xl mx-auto">
         <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-8">
           Donation Policy

--- a/src/app/donation-policy/page.tsx
+++ b/src/app/donation-policy/page.tsx
@@ -5,7 +5,9 @@ const PAGE_NAME = 'Donation Policy'
 const CANONICAL_PATH = '/donation-policy'
 
 export const metadata: Metadata = {
-  title: `${PAGE_NAME} | Free For Charity`,
+  // The root layout's title template appends " | Free For Charity", so the
+  // page title is just the page name (avoids a doubled brand suffix).
+  title: PAGE_NAME,
   description: 'Donation Policy for Free For Charity website',
   alternates: { canonical: CANONICAL_PATH },
 }

--- a/src/app/donation-policy/page.tsx
+++ b/src/app/donation-policy/page.tsx
@@ -1,16 +1,19 @@
 import type { Metadata } from 'next'
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
+const PAGE_NAME = 'Donation Policy'
+const CANONICAL_PATH = '/donation-policy'
+
 export const metadata: Metadata = {
-  title: 'Donation Policy | Free For Charity',
+  title: `${PAGE_NAME} | Free For Charity`,
   description: 'Donation Policy for Free For Charity website',
-  alternates: { canonical: '/donation-policy' },
+  alternates: { canonical: CANONICAL_PATH },
 }
 
 export default function DonationPolicy() {
   return (
     <div className="ffc-container py-16">
-      <BreadcrumbSchema name="Donation Policy" path="/donation-policy" />
+      <BreadcrumbSchema name={PAGE_NAME} path={CANONICAL_PATH} />
       <div className="max-w-4xl mx-auto">
         <h1 className="font-[var(--font-faustina)] text-[48px] leading-[60px] mb-8">
           Donation Policy

--- a/src/app/free-for-charity-donation-policy/page.tsx
+++ b/src/app/free-for-charity-donation-policy/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Metadata } from 'next'
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
 export const metadata: Metadata = {
   title: 'Free For Charity Donation Policy | Free For Charity',
@@ -10,6 +11,10 @@ export const metadata: Metadata = {
 const index = () => {
   return (
     <div className="pt-[140px]">
+      <BreadcrumbSchema
+        name="Free For Charity Donation Policy"
+        path="/free-for-charity-donation-policy"
+      />
       <div className="py-[21px] w-[90%] md:w-[80%] mx-auto max-w-[1080px]">
         <div className="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[30px] font-[500]">

--- a/src/app/free-for-charity-donation-policy/page.tsx
+++ b/src/app/free-for-charity-donation-policy/page.tsx
@@ -6,7 +6,9 @@ const PAGE_NAME = 'Free For Charity Donation Policy'
 const CANONICAL_PATH = '/free-for-charity-donation-policy'
 
 export const metadata: Metadata = {
-  title: `${PAGE_NAME} | Free For Charity`,
+  // The root layout's title template appends " | Free For Charity", so the
+  // page title is just the page name (avoids a doubled brand suffix).
+  title: PAGE_NAME,
   description: 'Free For Charity Donation Policy - Learn about our donation policies',
   alternates: { canonical: CANONICAL_PATH },
 }

--- a/src/app/free-for-charity-donation-policy/page.tsx
+++ b/src/app/free-for-charity-donation-policy/page.tsx
@@ -2,19 +2,19 @@ import React from 'react'
 import type { Metadata } from 'next'
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
+const PAGE_NAME = 'Free For Charity Donation Policy'
+const CANONICAL_PATH = '/free-for-charity-donation-policy'
+
 export const metadata: Metadata = {
-  title: 'Free For Charity Donation Policy | Free For Charity',
+  title: `${PAGE_NAME} | Free For Charity`,
   description: 'Free For Charity Donation Policy - Learn about our donation policies',
-  alternates: { canonical: '/free-for-charity-donation-policy' },
+  alternates: { canonical: CANONICAL_PATH },
 }
 
 const index = () => {
   return (
     <div className="pt-[140px]">
-      <BreadcrumbSchema
-        name="Free For Charity Donation Policy"
-        path="/free-for-charity-donation-policy"
-      />
+      <BreadcrumbSchema name={PAGE_NAME} path={CANONICAL_PATH} />
       <div className="py-[21px] w-[90%] md:w-[80%] mx-auto max-w-[1080px]">
         <div className="aria-font">
           <h1 className="text-[30px] text-[#333] pb-[10px] leading-[30px] font-[500]">

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
 export const metadata: Metadata = {
   title: 'Privacy Policy | Free For Charity',
@@ -9,6 +10,7 @@ export const metadata: Metadata = {
 export default function PrivacyPolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
+      <BreadcrumbSchema name="Privacy Policy" path="/privacy-policy" />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="aria-font">
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]"></p>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,16 +1,19 @@
 import type { Metadata } from 'next'
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
+const PAGE_NAME = 'Privacy Policy'
+const CANONICAL_PATH = '/privacy-policy'
+
 export const metadata: Metadata = {
-  title: 'Privacy Policy | Free For Charity',
+  title: `${PAGE_NAME} | Free For Charity`,
   description: 'Privacy Policy for Free For Charity website',
-  alternates: { canonical: '/privacy-policy' },
+  alternates: { canonical: CANONICAL_PATH },
 }
 
 export default function PrivacyPolicy() {
   return (
     <div className="pt-[140px] pb-[54px]">
-      <BreadcrumbSchema name="Privacy Policy" path="/privacy-policy" />
+      <BreadcrumbSchema name={PAGE_NAME} path={CANONICAL_PATH} />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="aria-font">
           <p className="text-[14px] text-[#666] pb-[10px] leading-[24px] font-[500]"></p>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -5,7 +5,9 @@ const PAGE_NAME = 'Privacy Policy'
 const CANONICAL_PATH = '/privacy-policy'
 
 export const metadata: Metadata = {
-  title: `${PAGE_NAME} | Free For Charity`,
+  // The root layout's title template appends " | Free For Charity", so the
+  // page title is just the page name (avoids a doubled brand suffix).
+  title: PAGE_NAME,
   description: 'Privacy Policy for Free For Charity website',
   alternates: { canonical: CANONICAL_PATH },
 }

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -7,7 +7,9 @@ const PAGE_NAME = 'Security Acknowledgements'
 const CANONICAL_PATH = '/security-acknowledgements'
 
 export const metadata: Metadata = {
-  title: `${PAGE_NAME} | Free For Charity`,
+  // The root layout's title template appends " | Free For Charity", so the
+  // page title is just the page name (avoids a doubled brand suffix).
+  title: PAGE_NAME,
   description: 'Security Acknowledgements for Free For Charity website',
   alternates: { canonical: CANONICAL_PATH },
 }

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'next/link'
 import type { Metadata } from 'next'
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
 export const metadata: Metadata = {
   title: 'Security Acknowledgements | Free For Charity',
@@ -11,6 +12,7 @@ export const metadata: Metadata = {
 const index = () => {
   return (
     <div className="pt-[130px] pb-[54px]">
+      <BreadcrumbSchema name="Security Acknowledgements" path="/security-acknowledgements" />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="border-t-[5px] border-[#0073e6] pt-[25px] lato-font">
           <h2 className="text-[30px] leading-[30px] font-[700] text-[#333] mt-[20px] mb-[25px]">

--- a/src/app/security-acknowledgements/page.tsx
+++ b/src/app/security-acknowledgements/page.tsx
@@ -3,16 +3,19 @@ import Link from 'next/link'
 import type { Metadata } from 'next'
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
+const PAGE_NAME = 'Security Acknowledgements'
+const CANONICAL_PATH = '/security-acknowledgements'
+
 export const metadata: Metadata = {
-  title: 'Security Acknowledgements | Free For Charity',
+  title: `${PAGE_NAME} | Free For Charity`,
   description: 'Security Acknowledgements for Free For Charity website',
-  alternates: { canonical: '/security-acknowledgements' },
+  alternates: { canonical: CANONICAL_PATH },
 }
 
 const index = () => {
   return (
     <div className="pt-[130px] pb-[54px]">
-      <BreadcrumbSchema name="Security Acknowledgements" path="/security-acknowledgements" />
+      <BreadcrumbSchema name={PAGE_NAME} path={CANONICAL_PATH} />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="border-t-[5px] border-[#0073e6] pt-[25px] lato-font">
           <h2 className="text-[30px] leading-[30px] font-[700] text-[#333] mt-[20px] mb-[25px]">

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -5,7 +5,9 @@ const PAGE_NAME = 'Terms of Service'
 const CANONICAL_PATH = '/terms-of-service'
 
 export const metadata: Metadata = {
-  title: `${PAGE_NAME} | Free For Charity`,
+  // The root layout's title template appends " | Free For Charity", so the
+  // page title is just the page name (avoids a doubled brand suffix).
+  title: PAGE_NAME,
   description: 'Terms of Service for Free For Charity website',
   alternates: { canonical: CANONICAL_PATH },
 }

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
 export const metadata: Metadata = {
   title: 'Terms of Service | Free For Charity',
@@ -9,6 +10,7 @@ export const metadata: Metadata = {
 export default function TermsOfService() {
   return (
     <div className="pt-[130px] pb-[54px]">
+      <BreadcrumbSchema name="Terms of Service" path="/terms-of-service" />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="aria-font">
           {/* Effective Date */}

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,16 +1,19 @@
 import type { Metadata } from 'next'
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
+const PAGE_NAME = 'Terms of Service'
+const CANONICAL_PATH = '/terms-of-service'
+
 export const metadata: Metadata = {
-  title: 'Terms of Service | Free For Charity',
+  title: `${PAGE_NAME} | Free For Charity`,
   description: 'Terms of Service for Free For Charity website',
-  alternates: { canonical: '/terms-of-service' },
+  alternates: { canonical: CANONICAL_PATH },
 }
 
 export default function TermsOfService() {
   return (
     <div className="pt-[130px] pb-[54px]">
-      <BreadcrumbSchema name="Terms of Service" path="/terms-of-service" />
+      <BreadcrumbSchema name={PAGE_NAME} path={CANONICAL_PATH} />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="aria-font">
           {/* Effective Date */}

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
 export const metadata: Metadata = {
   title: 'Vulnerability Disclosure Policy | Free For Charity',
@@ -9,6 +10,10 @@ export const metadata: Metadata = {
 export default function VulnerabilityDisclosurePolicy() {
   return (
     <div className="pt-[130px] pb-[54px]">
+      <BreadcrumbSchema
+        name="Vulnerability Disclosure Policy"
+        path="/vulnerability-disclosure-policy"
+      />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="lato-font">
           {/* Main Title */}

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -5,7 +5,9 @@ const PAGE_NAME = 'Vulnerability Disclosure Policy'
 const CANONICAL_PATH = '/vulnerability-disclosure-policy'
 
 export const metadata: Metadata = {
-  title: `${PAGE_NAME} | Free For Charity`,
+  // The root layout's title template appends " | Free For Charity", so the
+  // page title is just the page name (avoids a doubled brand suffix).
+  title: PAGE_NAME,
   description: 'Vulnerability Disclosure Policy for Free For Charity website',
   alternates: { canonical: CANONICAL_PATH },
 }

--- a/src/app/vulnerability-disclosure-policy/page.tsx
+++ b/src/app/vulnerability-disclosure-policy/page.tsx
@@ -1,19 +1,19 @@
 import type { Metadata } from 'next'
 import BreadcrumbSchema from '@/components/seo/BreadcrumbSchema'
 
+const PAGE_NAME = 'Vulnerability Disclosure Policy'
+const CANONICAL_PATH = '/vulnerability-disclosure-policy'
+
 export const metadata: Metadata = {
-  title: 'Vulnerability Disclosure Policy | Free For Charity',
+  title: `${PAGE_NAME} | Free For Charity`,
   description: 'Vulnerability Disclosure Policy for Free For Charity website',
-  alternates: { canonical: '/vulnerability-disclosure-policy' },
+  alternates: { canonical: CANONICAL_PATH },
 }
 
 export default function VulnerabilityDisclosurePolicy() {
   return (
     <div className="pt-[130px] pb-[54px]">
-      <BreadcrumbSchema
-        name="Vulnerability Disclosure Policy"
-        path="/vulnerability-disclosure-policy"
-      />
+      <BreadcrumbSchema name={PAGE_NAME} path={CANONICAL_PATH} />
       <div className="py-[27px] w-[90%] md:w-[80%] mx-auto">
         <div className="lato-font">
           {/* Main Title */}

--- a/src/components/seo/BreadcrumbSchema.tsx
+++ b/src/components/seo/BreadcrumbSchema.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { siteUrl } from '@/lib/site.config'
+
+type BreadcrumbProps = {
+  /** Title of the current page, shown as the last crumb (e.g. "Privacy Policy"). */
+  name: string
+  /** Same-origin absolute path of the current page (e.g. "/privacy-policy"). */
+  path: string
+}
+
+/**
+ * Builds a schema.org BreadcrumbList JSON-LD object for a sub-page: a simple
+ * two-level trail of Home → <this page>. Helps search engines render a
+ * breadcrumb trail in results and understand the site hierarchy. Absolute URLs
+ * come from `siteUrl()` so a fork only edits `site.config.ts`. Exported
+ * separately so it can be asserted in unit tests without rendering.
+ */
+export function buildBreadcrumbSchema(name: string, path: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: siteUrl('/'),
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name,
+        item: siteUrl(path),
+      },
+    ],
+  }
+}
+
+/**
+ * Emits a single <script type="application/ld+json"> block carrying a
+ * BreadcrumbList schema. Render once near the top of a sub-page (the legal
+ * pages). Not used on the single-page home, which has no parent to point back
+ * to.
+ *
+ * Server component — no client runtime cost.
+ */
+export default function BreadcrumbSchema({ name, path }: BreadcrumbProps) {
+  const schema = buildBreadcrumbSchema(name, path)
+  // Escape '<' as its JSON unicode form so a value containing "</script>"
+  // cannot break out of this inline script tag (JSON-LD injection guard).
+  const json = JSON.stringify(schema).replace(/</g, '\\u003c')
+  return (
+    <script
+      type="application/ld+json"
+      // dangerouslySetInnerHTML is the standard pattern for inline JSON-LD per
+      // the Next.js docs.
+      dangerouslySetInnerHTML={{ __html: json }}
+    />
+  )
+}


### PR DESCRIPTION
## Description

Adds `schema.org/BreadcrumbList` structured data to the 7 legal sub-pages so search
engines can render a breadcrumb trail (Home → Page) and better understand the site
hierarchy. Deliberately **not** added to the single-page home, which has no parent.

While addressing review feedback, this also extracts per-page constants and fixes a
pre-existing doubled-brand-name bug in the legal page titles.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (doubled brand suffix in legal page `<title>`)
- [x] Code refactoring (per-page DRY constants)

## Changes Made

- **New `src/components/seo/BreadcrumbSchema.tsx`** — server component mirroring `WebsiteSchema.tsx`: exported `buildBreadcrumbSchema(name, path)` builder, `<`-escaped JSON-LD, absolute URLs from `siteUrl()`. Emits a two-item list (Home → page).
- Rendered `<BreadcrumbSchema>` on each of the 7 legal pages, reusing each page's canonical path and title.
- **New `__tests__/components/seo/BreadcrumbSchema.test.tsx`** — asserts the two-item structure, absolute https URLs, and that one JSON-LD script renders and parses.
- **DRY refactor (Copilot review feedback):** each legal page now defines `PAGE_NAME` and `CANONICAL_PATH` module constants and reuses them in both `metadata` and the breadcrumb props, so the canonical URL and the JSON-LD breadcrumb can't drift apart.
- **Bug fix:** the root layout already applies a `'%s | Free For Charity'` title template, but each legal page also hardcoded `| Free For Charity` in its own title — rendering a doubled suffix (e.g. `Privacy Policy | Free For Charity | Free For Charity`). Each page title is now just `PAGE_NAME`, so the template adds the single brand suffix. This bug pre-existed on `main`.

## Testing Performed

### Automated Testing

- [x] `npm run lint` — 0 warnings (changed files)
- [x] `npm test` — 108/108 unit tests pass (3 new)
- [x] `npm run build` — static export succeeds
- [x] Verified each `out/<legal>.html` has exactly one `BreadcrumbList` (Home → page, absolute URLs); `out/index.html` has none
- [x] Verified legal `<title>` tags now render a single brand suffix; home title unaffected

## Breaking Changes

None / N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)