### PR TITLE
test: cover Testimonials, Events, error/not-found, data modules

### DIFF
--- a/__tests__/app/error.test.tsx
+++ b/__tests__/app/error.test.tsx
@@ -17,7 +17,9 @@ describe('error page (GlobalError)', () => {
   it('renders branded error copy', () => {
     render(<GlobalError error={new Error('boom')} reset={() => {}} />)
     expect(screen.getByRole('heading', { name: /unexpected error/i })).toBeInTheDocument()
-    expect(screen.getByText(new RegExp(siteConfig.name))).toBeInTheDocument()
+    // Substring match (not a RegExp built from config) so a fork name with
+    // regex metacharacters can't break or throw.
+    expect(screen.getByText(siteConfig.name, { exact: false })).toBeInTheDocument()
   })
 
   it('calls reset when "Try again" is clicked', () => {

--- a/__tests__/app/error.test.tsx
+++ b/__tests__/app/error.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import GlobalError from '@/app/error'
+import { siteConfig } from '@/lib/site.config'
+
+describe('error page (GlobalError)', () => {
+  // The component logs to console.error outside production; silence it so the
+  // test output stays clean.
+  let errorSpy: jest.SpyInstance
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it('renders branded error copy', () => {
+    render(<GlobalError error={new Error('boom')} reset={() => {}} />)
+    expect(screen.getByRole('heading', { name: /unexpected error/i })).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(siteConfig.name))).toBeInTheDocument()
+  })
+
+  it('calls reset when "Try again" is clicked', () => {
+    const reset = jest.fn()
+    render(<GlobalError error={new Error('boom')} reset={reset} />)
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the digest reference id when present', () => {
+    const err = Object.assign(new Error('boom'), { digest: 'abc123' })
+    render(<GlobalError error={err} reset={() => {}} />)
+    expect(screen.getByText(/abc123/)).toBeInTheDocument()
+  })
+})

--- a/__tests__/app/not-found.test.tsx
+++ b/__tests__/app/not-found.test.tsx
@@ -7,7 +7,9 @@ describe('not-found page', () => {
   it('renders branded 404 copy', () => {
     render(<NotFound />)
     expect(screen.getByRole('heading', { name: /can.?t find that page/i })).toBeInTheDocument()
-    expect(screen.getByText(new RegExp(siteConfig.name))).toBeInTheDocument()
+    // Substring match (not a RegExp built from config) so a fork name with
+    // regex metacharacters can't break or throw.
+    expect(screen.getByText(siteConfig.name, { exact: false })).toBeInTheDocument()
   })
 
   it('links to the homepage and the disclosure path', () => {

--- a/__tests__/app/not-found.test.tsx
+++ b/__tests__/app/not-found.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import NotFound, { metadata } from '@/app/not-found'
+import { siteConfig } from '@/lib/site.config'
+
+describe('not-found page', () => {
+  it('renders branded 404 copy', () => {
+    render(<NotFound />)
+    expect(screen.getByRole('heading', { name: /can.?t find that page/i })).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(siteConfig.name))).toBeInTheDocument()
+  })
+
+  it('links to the homepage and the disclosure path', () => {
+    render(<NotFound />)
+    expect(screen.getByRole('link', { name: /go to homepage/i })).toHaveAttribute('href', '/')
+    expect(screen.getByRole('link', { name: /report an issue/i })).toHaveAttribute(
+      'href',
+      siteConfig.vulnerabilityDisclosurePath
+    )
+  })
+
+  it('is excluded from search indexing', () => {
+    expect(metadata.robots).toEqual({ index: false, follow: false })
+  })
+})

--- a/__tests__/components/Events.test.tsx
+++ b/__tests__/components/Events.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Events from '@/components/home-page/Events'
+import { siteConfig } from '@/lib/site.config'
+
+describe('Events component', () => {
+  it('renders the section heading', () => {
+    render(<Events />)
+    expect(screen.getByRole('heading', { name: 'Upcoming Events' })).toBeInTheDocument()
+  })
+
+  it('renders the SociableKit events iframe from siteConfig with safe attributes', () => {
+    render(<Events />)
+    const iframe = screen.getByTitle('Facebook Events')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe.getAttribute('src')).toBe(siteConfig.integrations.sociableKitEventsWidgetUrl)
+    expect(iframe.getAttribute('loading')).toBe('lazy')
+    expect(iframe.getAttribute('sandbox')).toContain('allow-scripts')
+  })
+})

--- a/__tests__/components/Testimonials.test.tsx
+++ b/__tests__/components/Testimonials.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+// Swiper ships ESM that jest's transform doesn't process; stub the carousel
+// shell so we can test the component's own markup (headings, slides, controls).
+// The CSS side-effect imports are virtual-mocked to avoid resolving real files.
+jest.mock('swiper/react', () => ({
+  Swiper: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="swiper">{children}</div>
+  ),
+  SwiperSlide: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+jest.mock('swiper/modules', () => ({ Navigation: {}, Autoplay: {} }))
+jest.mock('swiper/css', () => ({}), { virtual: true })
+jest.mock('swiper/css/navigation', () => ({}), { virtual: true })
+
+import Testimonials from '@/components/home-page/Testimonials'
+import { testimonials } from '@/data/testimonials'
+
+describe('Testimonials component', () => {
+  it('renders the section heading', () => {
+    render(<Testimonials />)
+    expect(screen.getByRole('heading', { name: 'Testimonials' })).toBeInTheDocument()
+  })
+
+  it('renders the first testimonial heading and text', () => {
+    render(<Testimonials />)
+    // The heading text can also appear as the testimonial's location label, so
+    // assert at least one match; the body text is unique.
+    expect(screen.getAllByText(testimonials[0].heading).length).toBeGreaterThan(0)
+    expect(screen.getByText(testimonials[0].text)).toBeInTheDocument()
+  })
+
+  it('exposes accessible prev/next controls', () => {
+    render(<Testimonials />)
+    expect(screen.getByRole('button', { name: /previous testimonial/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /next testimonial/i })).toBeInTheDocument()
+  })
+})

--- a/__tests__/data/data-modules.test.ts
+++ b/__tests__/data/data-modules.test.ts
@@ -1,0 +1,63 @@
+import { testimonials } from '@/data/testimonials'
+import { team } from '@/data/team'
+import { faqs } from '@/data/faqs'
+import { results } from '@/data/results'
+
+// These validate the data contract a forking charity must follow when editing
+// the JSON/TS under src/data/* — every item must carry the fields its component
+// renders, so a malformed edit fails the suite instead of the live site.
+describe('data modules', () => {
+  describe('testimonials', () => {
+    it('is a non-empty array', () => {
+      expect(Array.isArray(testimonials)).toBe(true)
+      expect(testimonials.length).toBeGreaterThan(0)
+    })
+    it('every entry has a heading and text', () => {
+      for (const t of testimonials) {
+        expect(typeof t.heading).toBe('string')
+        expect(t.heading.length).toBeGreaterThan(0)
+        expect(typeof t.text).toBe('string')
+        expect(t.text.length).toBeGreaterThan(0)
+      }
+    })
+  })
+
+  describe('team', () => {
+    it('is a non-empty array', () => {
+      expect(team.length).toBeGreaterThan(0)
+    })
+    it('every member has name, title, an /Images/ photo, and an http(s) LinkedIn URL', () => {
+      for (const m of team) {
+        expect(m.name).toBeTruthy()
+        expect(m.title).toBeTruthy()
+        expect(m.imageUrl).toMatch(/^\/Images\//)
+        expect(m.linkedinUrl).toMatch(/^https?:\/\//)
+      }
+    })
+  })
+
+  describe('faqs', () => {
+    it('is a non-empty array', () => {
+      expect(faqs.length).toBeGreaterThan(0)
+    })
+    it('every entry has a question and an answer', () => {
+      for (const f of faqs) {
+        expect(f.question).toBeTruthy()
+        expect(f.answer).toBeTruthy()
+      }
+    })
+  })
+
+  describe('results', () => {
+    it('has a heading and a non-empty stats array', () => {
+      expect(results.heading).toBeTruthy()
+      expect(results.stats.length).toBeGreaterThan(0)
+    })
+    it('every stat has a value and a label', () => {
+      for (const s of results.stats) {
+        expect(s.value).toBeTruthy()
+        expect(s.label).toBeTruthy()
+      }
+    })
+  })
+})

--- a/__tests__/data/data-modules.test.ts
+++ b/__tests__/data/data-modules.test.ts
@@ -24,6 +24,7 @@ describe('data modules', () => {
 
   describe('team', () => {
     it('is a non-empty array', () => {
+      expect(Array.isArray(team)).toBe(true)
       expect(team.length).toBeGreaterThan(0)
     })
     it('every member has name, title, an /Images/ photo, and an http(s) LinkedIn URL', () => {
@@ -38,6 +39,7 @@ describe('data modules', () => {
 
   describe('faqs', () => {
     it('is a non-empty array', () => {
+      expect(Array.isArray(faqs)).toBe(true)
       expect(faqs.length).toBeGreaterThan(0)
     })
     it('every entry has a question and an answer', () => {
@@ -51,6 +53,7 @@ describe('data modules', () => {
   describe('results', () => {
     it('has a heading and a non-empty stats array', () => {
       expect(results.heading).toBeTruthy()
+      expect(Array.isArray(results.stats)).toBe(true)
       expect(results.stats.length).toBeGreaterThan(0)
     })
     it('every stat has a value and a label', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,15 +21,15 @@ const customJestConfig = {
     '!src/app/layout.tsx', // Exclude layout due to font imports causing issues
   ],
   // Coverage floors set a few points below the current measured coverage
-  // (branches ~47%, functions ~59%, lines/statements ~60%) so a real
+  // (branches ~51%, functions ~65%, lines/statements ~65%) so a real
   // regression fails CI, while leaving enough margin that a trivial diff
   // adding one uncovered branch doesn't. Raise these as coverage improves.
   coverageThreshold: {
     global: {
-      branches: 40,
-      functions: 50,
-      lines: 50,
-      statements: 50,
+      branches: 45,
+      functions: 58,
+      lines: 58,
+      statements: 58,
     },
   },
   moduleNameMapper: {


### PR DESCRIPTION
## Description

Closes the biggest unit-test gaps in the template and ratchets the coverage floor up
accordingly, so the Batch-5 coverage guard now protects a higher baseline.

## Type of Change

- [x] Test addition/update

## Changes Made

- New tests for previously-untested code:
  - **Data modules** (`__tests__/data/data-modules.test.ts`): assert `src/data/{testimonials,team,faqs,results}` export non-empty data and every item carries the fields its TS type/component requires — i.e. the data contract a forking charity must follow.
  - **Testimonials** component: heading renders, first testimonial's heading/text render, prev/next controls have `aria-label`s. Swiper's ESM is stubbed (jest can't transform it) and its CSS side-effects are virtual-mocked.
  - **Events** component: renders the SociableKit iframe from `siteConfig` with `title`, `loading="lazy"`, and `sandbox`.
  - **not-found** page: branded copy, homepage + disclosure links, and `robots: {index:false, follow:false}` metadata.
  - **error** page (`GlobalError`): branded copy, `reset` fires on "Try again", and the digest reference renders.
- Measured coverage rose to ~65% lines/statements, ~65% functions, ~51% branches; raised `jest.config.js` `coverageThreshold.global` from `50/50/40` to **58/58/45** (statements/lines/functions/branches), a few points below measured.

## Related Issue(s)

Refs the template-quality improvement batch (Batch 6).

## Testing Performed

### Automated Testing

- [x] `npm run test:coverage` — 127/127 pass at the raised floors
- [x] `npm run lint` — 0 warnings (changed files)
- [x] `npm run build` — static export succeeds
- [x] `npm run check:drift` — no drift

## Breaking Changes

None / N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_