### PR TITLE
perf: iframe loading skeletons + lazy Zeffy (and stabilize GTM e2e)

### DIFF
--- a/__tests__/components/iframe-embeds.test.tsx
+++ b/__tests__/components/iframe-embeds.test.tsx
@@ -25,11 +25,8 @@ describe('iframe embeds', () => {
   })
 
   describe('Events widget', () => {
-    it('lazy-loads the events iframe', () => {
-      render(<Events />)
-      expect(screen.getByTitle('Facebook Events').getAttribute('loading')).toBe('lazy')
-    })
-
+    // The Events iframe's loading="lazy" / src / sandbox contract is covered by
+    // __tests__/components/Events.test.tsx; only the skeleton is asserted here.
     it('renders a decorative, reduced-motion-safe loading skeleton', () => {
       const { container } = render(<Events />)
       const skeleton = container.querySelector('[aria-hidden="true"].animate-pulse')

--- a/__tests__/components/iframe-embeds.test.tsx
+++ b/__tests__/components/iframe-embeds.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SupportFreeForCharity from '@/components/home-page/SupportFreeForCharity'
+import Events from '@/components/home-page/Events'
+
+// Locks in the perceived-performance + accessibility behavior of the two
+// third-party iframe embeds: each lazy-loads and sits over a decorative,
+// reduced-motion-safe loading skeleton.
+describe('iframe embeds', () => {
+  describe('Zeffy donation form', () => {
+    it('lazy-loads the donation iframe', () => {
+      render(<SupportFreeForCharity />)
+      expect(screen.getByTitle('Donation form powered by Zeffy').getAttribute('loading')).toBe(
+        'lazy'
+      )
+    })
+
+    it('renders a decorative, reduced-motion-safe loading skeleton', () => {
+      const { container } = render(<SupportFreeForCharity />)
+      const skeleton = container.querySelector('[aria-hidden="true"].animate-pulse')
+      expect(skeleton).not.toBeNull()
+      expect(skeleton?.className).toContain('pointer-events-none')
+      expect(skeleton?.className).toContain('motion-reduce:animate-none')
+    })
+  })
+
+  describe('Events widget', () => {
+    it('lazy-loads the events iframe', () => {
+      render(<Events />)
+      expect(screen.getByTitle('Facebook Events').getAttribute('loading')).toBe('lazy')
+    })
+
+    it('renders a decorative, reduced-motion-safe loading skeleton', () => {
+      const { container } = render(<Events />)
+      const skeleton = container.querySelector('[aria-hidden="true"].animate-pulse')
+      expect(skeleton).not.toBeNull()
+      expect(skeleton?.className).toContain('pointer-events-none')
+      expect(skeleton?.className).toContain('motion-reduce:animate-none')
+    })
+  })
+})

--- a/src/components/home-page/Events/index.tsx
+++ b/src/components/home-page/Events/index.tsx
@@ -17,17 +17,23 @@ const Events = () => {
 
         {/* SociableKit Facebook Events Widget */}
         <div className="flex justify-center">
-          <iframe
-            src={siteConfig.integrations.sociableKitEventsWidgetUrl}
-            frameBorder={0}
-            width="100%"
-            height="1000"
-            style={{ maxWidth: '1200px' }}
-            title="Facebook Events"
-            loading="lazy"
-            className="rounded-lg"
-            sandbox="allow-scripts allow-same-origin"
-          ></iframe>
+          <div className="relative w-full max-w-[1200px]">
+            {/* CSS-only loading placeholder shown until the lazy iframe loads. */}
+            <div
+              className="absolute inset-0 animate-pulse bg-gray-100 rounded-lg"
+              aria-hidden="true"
+            />
+            <iframe
+              src={siteConfig.integrations.sociableKitEventsWidgetUrl}
+              frameBorder={0}
+              width="100%"
+              height="1000"
+              title="Facebook Events"
+              loading="lazy"
+              className="relative rounded-lg"
+              sandbox="allow-scripts allow-same-origin"
+            ></iframe>
+          </div>
         </div>
 
         <div className="text-center mt-8">

--- a/src/components/home-page/Events/index.tsx
+++ b/src/components/home-page/Events/index.tsx
@@ -20,7 +20,7 @@ const Events = () => {
           <div className="relative w-full max-w-[1200px]">
             {/* CSS-only loading placeholder shown until the lazy iframe loads. */}
             <div
-              className="absolute inset-0 animate-pulse bg-gray-100 rounded-lg"
+              className="absolute inset-0 animate-pulse bg-gray-100 rounded-lg pointer-events-none motion-reduce:animate-none"
               aria-hidden="true"
             />
             <iframe

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -24,6 +24,7 @@ const Index = () => {
     title: 'Donation form powered by Zeffy',
     style: donationFormStyle,
     src: siteConfig.integrations.zeffyDonationUrl,
+    loading: 'lazy',
     allowpaymentrequest: '',
     allowtransparency: 'true',
   }
@@ -63,6 +64,9 @@ const Index = () => {
               role="region"
               aria-label="Donation form"
             >
+              {/* CSS-only loading placeholder; the transparent Zeffy iframe
+                  paints over it once the form loads. Purely decorative. */}
+              <div className="absolute inset-0 animate-pulse bg-gray-100" aria-hidden="true" />
               <iframe {...donationFormProps}></iframe>
             </div>
           </div>

--- a/src/components/home-page/SupportFreeForCharity/index.tsx
+++ b/src/components/home-page/SupportFreeForCharity/index.tsx
@@ -66,7 +66,10 @@ const Index = () => {
             >
               {/* CSS-only loading placeholder; the transparent Zeffy iframe
                   paints over it once the form loads. Purely decorative. */}
-              <div className="absolute inset-0 animate-pulse bg-gray-100" aria-hidden="true" />
+              <div
+                className="absolute inset-0 animate-pulse bg-gray-100 pointer-events-none motion-reduce:animate-none"
+                aria-hidden="true"
+              />
               <iframe {...donationFormProps}></iframe>
             </div>
           </div>

--- a/tests/google-tag-manager.spec.ts
+++ b/tests/google-tag-manager.spec.ts
@@ -17,7 +17,14 @@ test.describe('Google Tag Manager Integration', () => {
   test('should initialize dataLayer on page load', async ({ page }) => {
     await page.goto('/')
 
-    // Check if dataLayer exists and is initialized
+    // GTM loads via next/script (lazyOnload), so dataLayer appears after the
+    // load event — wait for it rather than reading immediately (avoids a race).
+    await page.waitForFunction(
+      () => typeof window.dataLayer !== 'undefined' && Array.isArray(window.dataLayer),
+      null,
+      { timeout: 15000 }
+    )
+
     const hasDataLayer = await page.evaluate(() => {
       return typeof window.dataLayer !== 'undefined' && Array.isArray(window.dataLayer)
     })
@@ -28,12 +35,13 @@ test.describe('Google Tag Manager Integration', () => {
   test('should load GTM script with correct ID', async ({ page }) => {
     await page.goto('/')
 
-    // Check for GTM script element
-    const gtmScript = await page.locator('script[id="gtm-script"]').count()
-    expect(gtmScript).toBeGreaterThan(0)
+    // The GTM snippet is injected by next/script (lazyOnload) after load, so
+    // wait for it to attach instead of counting immediately (avoids a race).
+    const gtmScript = page.locator('script[id="gtm-script"]')
+    await expect(gtmScript.first()).toBeAttached({ timeout: 15000 })
 
     // Verify script contains GTM initialization code
-    const scriptContent = await page.locator('script[id="gtm-script"]').innerHTML()
+    const scriptContent = await gtmScript.first().innerHTML()
     expect(scriptContent).toContain('googletagmanager.com/gtm.js')
     expect(scriptContent).toContain('dataLayer')
   })
@@ -51,6 +59,11 @@ test.describe('Google Tag Manager Integration', () => {
   test('should push events to dataLayer', async ({ page }) => {
     await page.goto('/')
 
+    // dataLayer is initialized by the lazyOnload GTM snippet — wait for it.
+    await page.waitForFunction(() => typeof window.dataLayer !== 'undefined', null, {
+      timeout: 15000,
+    })
+
     // Verify we can push events to dataLayer
     const canPushToDataLayer = await page.evaluate(() => {
       if (typeof window.dataLayer === 'undefined') return false
@@ -66,9 +79,16 @@ test.describe('Google Tag Manager Integration', () => {
   test('should load GTM script after page interaction', async ({ page }) => {
     await page.goto('/')
 
-    // Verify GTM script exists on the page
-    // Note: Next.js Script component with lazyOnload strategy
-    // defers script loading until after page is interactive
+    // Next.js Script (lazyOnload) defers the GTM snippet + dataLayer until
+    // after the page is interactive — wait for both before asserting.
+    await page.waitForFunction(
+      () =>
+        document.querySelector('script[id="gtm-script"]') !== null &&
+        typeof window.dataLayer !== 'undefined',
+      null,
+      { timeout: 15000 }
+    )
+
     const gtmScript = await page.evaluate(() => {
       const script = document.querySelector('script[id="gtm-script"]')
       return script !== null
@@ -117,14 +137,13 @@ test.describe('Google Tag Manager Configuration', () => {
 
     await page.goto('/')
 
-    // GTM script should always be present with the configured ID
-    const gtmScript = await page.locator('script[id="gtm-script"]').count()
-
-    // Script should be present
-    expect(gtmScript).toBeGreaterThan(0)
+    // GTM snippet is injected by next/script (lazyOnload) after load — wait for
+    // it to attach rather than counting immediately (avoids a race).
+    const gtmScript = page.locator('script[id="gtm-script"]')
+    await expect(gtmScript.first()).toBeAttached({ timeout: 15000 })
 
     // Verify the script contains the correct GTM ID
-    const scriptContent = await page.locator('script[id="gtm-script"]').innerHTML()
+    const scriptContent = await gtmScript.first().innerHTML()
     expect(scriptContent).toContain(testConfig.googleTagManager.id)
   })
 })


### PR DESCRIPTION
## Description

CSS-only loading skeletons behind the two third-party iframe embeds (Zeffy donation form,
SociableKit events widget) plus lazy-loading the Zeffy iframe — better perceived performance
with no added JavaScript.

While verifying CI, the lazy-load change surfaced (and this PR fixes) a pre-existing race in
the Playwright GTM tests — see "GTM e2e stabilization" below.

## Type of Change

- [x] Performance improvement
- [x] Test stabilization (Playwright GTM specs)

## Changes Made

- **Zeffy** (`SupportFreeForCharity/index.tsx`): `loading="lazy"` on the donation iframe + an `aria-hidden`, `pointer-events-none`, `motion-reduce:animate-none` `animate-pulse` skeleton behind it.
- **Events** (`Events/index.tsx`): wrapped the iframe in a `relative` container with the same skeleton layer (it already lazy-loads).
- **`__tests__/components/iframe-embeds.test.tsx`**: asserts each embed's skeleton is `aria-hidden` + reduced-motion-safe (and the Zeffy iframe lazy-loads).

### GTM e2e stabilization (`tests/google-tag-manager.spec.ts`)

GTM loads via `next/script` **`lazyOnload`**, which injects the snippet + `dataLayer` *after* the page's `load` event. The specs checked `script[id="gtm-script"]` / `dataLayer` **immediately**, racing that injection. Lazy-loading the Zeffy iframe makes `load` fire sooner, **widening the race** so the checks failed intermittently in CI (3 consecutive failures on this PR while other PRs passed the same suite). The 5 affected specs now **wait** for the injection (`toBeAttached` / `waitForFunction`, 15s) instead of reading immediately.

This also fixes the long-standing **sandbox** failures of these specs: with the `load` event now reached, the inline snippet injects `dataLayer` without needing the (network-blocked) `googletagmanager.com` — all 7 GTM specs pass locally.

## Testing Performed

- [x] `npm run lint` — 0 warnings (changed files)
- [x] `npm test` — 132/132 unit tests pass
- [x] `npm run build` — static export succeeds
- [x] `npx playwright test google-tag-manager` — 7/7 pass locally (previously failed in the sandbox)
- [x] `npm run check:drift` — no drift

## Breaking Changes

None / N/A — visual-only iframe change; GTM specs only made more robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)