### PR TITLE
perf: add resource hints and Organization parentOrganization

### DIFF
--- a/__tests__/components/seo/OrganizationSchema.test.tsx
+++ b/__tests__/components/seo/OrganizationSchema.test.tsx
@@ -53,6 +53,18 @@ describe('OrganizationSchema', () => {
     }
   })
 
+  it('links the parent organization when configured', () => {
+    const schema = buildOrganizationSchema()
+    if (siteConfig.parentOrg) {
+      const parent = schema.parentOrganization as Record<string, unknown>
+      expect(parent['@type']).toBe('NGO')
+      expect(parent.name).toBe(siteConfig.parentOrg.name)
+      expect(parent.url).toBe(siteConfig.parentOrg.url)
+    } else {
+      expect(schema.parentOrganization).toBeUndefined()
+    }
+  })
+
   it('renders a single application/ld+json script block whose JSON parses', () => {
     const { container } = render(<OrganizationSchema />)
     const scripts = container.querySelectorAll('script[type="application/ld+json"]')

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,13 +89,20 @@ export default function RootLayout({
         <meta name="color-scheme" content="light" />
         <meta name="theme-color" content={siteConfig.themeColor} />
 
-        {/* Preconnect to external domains for faster resource loading */}
+        {/* Preconnect to external domains that load on first paint */}
         <link rel="preconnect" href="https://www.googletagmanager.com" />
         <link rel="preconnect" href="https://www.zeffy.com" />
         <link rel="preconnect" href="https://widgets.guidestar.org" />
+        <link rel="preconnect" href="https://widgets.sociablekit.com" />
         <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
         <link rel="dns-prefetch" href="https://www.zeffy.com" />
+        <link rel="dns-prefetch" href="https://widgets.sociablekit.com" />
         <link rel="dns-prefetch" href="https://www.idealist.org" />
+        {/* Analytics endpoints load conditionally through GTM — dns-prefetch
+            only (cheaper than preconnect for resources that may not load). */}
+        <link rel="dns-prefetch" href="https://www.google-analytics.com" />
+        <link rel="dns-prefetch" href="https://www.clarity.ms" />
+        <link rel="dns-prefetch" href="https://connect.facebook.net" />
 
         {/* Preload critical LCP image */}
         <link

--- a/src/components/seo/OrganizationSchema.tsx
+++ b/src/components/seo/OrganizationSchema.tsx
@@ -46,6 +46,16 @@ export function buildOrganizationSchema(): Record<string, unknown> {
     }
   }
 
+  if (siteConfig.parentOrg) {
+    // When this site is "a project of" an umbrella org, link the two so search
+    // engines can relate them in the knowledge graph.
+    schema.parentOrganization = {
+      '@type': 'NGO',
+      name: siteConfig.parentOrg.name,
+      url: siteConfig.parentOrg.url,
+    }
+  }
+
   return schema
 }
 


### PR DESCRIPTION
## Description

Two small discoverability/performance wins: resource hints for the third-party origins
the page loads, and a `parentOrganization` link in the Organization structured data.

## Type of Change

- [x] Performance improvement
- [x] SEO / structured data

## Changes Made

- **Resource hints** (`src/app/layout.tsx` `<head>`): added `dns-prefetch` for the analytics endpoints that load conditionally through GTM (`google-analytics.com`, `clarity.ms`, `connect.facebook.net`) — dns-prefetch only, since they may not load, which is cheaper than eager `preconnect` — and `preconnect` + `dns-prefetch` for `widgets.sociablekit.com` (the Events embed renders on the page). All origins are already CSP-allowlisted; no CSP change.
- **OrganizationSchema** (`src/components/seo/OrganizationSchema.tsx`): when `siteConfig.parentOrg` is set, emit a `parentOrganization` NGO node (name + url) so a site that is "a project of" an umbrella org links to it in the knowledge graph. Conditional, matching the existing optional-field pattern. Test updated to assert it.

## Related Issue(s)

Refs the template-quality improvement batch (Batch 6).

## Testing Performed

### Automated Testing

- [x] `npm test` — 109/109 pass (OrganizationSchema test covers `parentOrganization`)
- [x] `npm run lint` — 0 warnings (changed files)
- [x] `npm run build` — static export succeeds; verified the new hints and a `parentOrganization` field render in `out/index.html`
- [x] `npm run check:drift` — no drift

## Breaking Changes

None / N/A — additive head links + one conditional schema field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtLfNqvMaMoT1qBx8zn6Nr)_