### PR TITLE
feat: harden rebrand tooling with an enforced brand-identity drift gate and skill

### DIFF
--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -31,9 +31,11 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
 
 7. **Footer** — no per-charity CODE edits needed. EIN, addresses, phone, GuideStar links, parent-org link, social rail, and email all come from `siteConfig` (set in step 2). The only footer-related swap is the GuideStar / endorsement seal IMAGE asset in `public/Svgs/` if the charity's endorsements differ.
 
-8. **Replace content** in `src/data/` (testimonials, FAQs, team) and the home-page sections under `src/components/home-page/`.
+8. **Replace or DELETE demo content.** Update the home-page sections under `src/components/home-page/` and `src/data/` (testimonials, FAQs, team) the charity keeps — and **delete the ones it doesn't**. Any `src/components/home-page/*` section not imported by `src/app/home-page/index.tsx` is dead; remove it and its test rather than leaving FFC content in the tree. Delete `src/data/{team,testimonials,faqs}` if nothing imports them. Keep brand-neutral reusable UI primitives.
 
-9. **Legal pages** under `src/app/{privacy-policy,terms-of-service,cookie-policy,donation-policy}` — REVIEW with the charity's counsel before committing. Update org name and contact references.
+9. **Legal pages — every one of them.** Under `src/app/`, update `privacy-policy`, `terms-of-service`, `cookie-policy`, `vulnerability-disclosure-policy`, and `security-acknowledgements`. For each: fix `metadata` (bare `title`, org-correct `description`, add `alternates.canonical`) and the body (org name, `freeforcharity.org` URLs, contact emails, phone, DPO name). Align the vulnerability-disclosure contact with `security.txt`. Handle the donation pages per the charity's donation posture — rebrand if they solicit donations, otherwise **delete them** and drop their `src/app/sitemap.ts` entries plus any Terms "Donation Policy" reference. Do NOT invent an EIN, governing-law state, or donation terms — leave blanks for the charity to confirm. **REVIEW all legal text with the charity's counsel before committing.**
+
+9b. **Per-page SEO.** Never set `alternates.canonical` on the root layout (App Router inherits it → every page canonicalizes to `/`); set it per page instead (home, `/articles`, each article via `generateMetadata`, every policy page). Keep policy `<title>`s bare so the layout template supplies the brand. Give article pages their own `openGraph`/`twitter` + `Article` JSON-LD.
 
 10. **GitHub repo settings** (web UI, not in code):
     - Settings → Pages → Source = **"GitHub Actions"** (NOT "Deploy from a branch" — there is no `gh-pages` branch).
@@ -59,6 +61,16 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
     Fix anything red before opening a PR. `check:rebrand` never fails the build —
     treat its checklist as the "did I replace every FFC default?" confirmation
     (charity name, EIN, phone, email, domain, GTM container, sample content).
+    `check:drift` **does** fail on leftover FFC identity in rendered pages: once
+    `siteConfig.name` changes, any `Free For Charity`, `freeforcharity.org`, EIN
+    `46-2471893`, phone `520-222-8104`, or `@freeforcharity.org` email in
+    `src/app/**` or `src/components/**` is a hard error (footer credit excepted).
+    As a final belt-and-suspenders sweep of surfaces neither check scans:
+
+    ```
+    grep -rniE 'free ?for ?charity|freeforcharity\.org|46-?2471893|520[-. ]?222[-. ]?8104' src/ public/ \
+      | grep -v 'Built with Free For Charity'
+    ```
 
 13. **Open a PR titled** `chore: initial customization for <Charity Name>` linking the onboarding issue. In the body include:
     - A checklist of every file edited
@@ -83,4 +95,7 @@ You are helping a Free For Charity volunteer or charity admin stand up a new sit
 
 ## Reference
 
-The full field-to-surface map lives in `TEMPLATE_CUSTOMIZATION.md`. The setup checklist in `TEMPLATE_SETUP_CHECKLIST.md` covers GitHub repo settings. The drift checker (`scripts/check-drift.mjs`) describes the platform contract you're working within.
+For a rebrand of an existing fork (as opposed to first-time onboarding), follow
+the **`rebrand` skill** (`.claude/skills/rebrand/SKILL.md`) — it covers the same
+ground with extra emphasis on deleting unused demo content, per-page SEO, and the
+brand-identity gate. The full field-to-surface map lives in `TEMPLATE_CUSTOMIZATION.md`. The setup checklist in `TEMPLATE_SETUP_CHECKLIST.md` covers GitHub repo settings. The drift checker (`scripts/check-drift.mjs`) describes the platform contract you're working within.

--- a/.claude/skills/rebrand/SKILL.md
+++ b/.claude/skills/rebrand/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: rebrand
+description: Rebrand this FFC template to a new nonprofit — swap identity, config, legal pages, and assets; delete unused demo content; fix per-page SEO; and verify nothing Free For Charity ships. Use when adapting the template to a new organization, or auditing a partially-rebranded fork for leftover "Free For Charity" identity.
+---
+
+# Rebrand the FFC template to a new organization
+
+This skill turns the template into a specific nonprofit's site **without leaving
+any Free For Charity identity behind**. It exists because the naive "find-and-
+replace Free For Charity on the homepage" approach repeatedly ships forks whose
+**legal pages, deep routes, and metadata still belong to FFC** — and passes
+lint/build/tests while doing so.
+
+Read this whole file before editing. Work top-to-bottom; the verification step
+at the end is mandatory.
+
+## Two checks, two jobs
+
+- `npm run check:rebrand` — an **advisory** checklist (exits 0) of FFC _config
+  and data_ defaults still present: `site.config.ts` values, the real GTM
+  container, `security.txt`, and the sample team/testimonials/FAQ data. Run it
+  early; run `npm run check:rebrand --strict` to make it exit non-zero while any
+  default remains.
+- `npm run check:drift` — an **enforced** CI gate. It now includes a
+  brand-identity check: once `siteConfig.name` differs from `Free For Charity`,
+  any leftover `Free For Charity`, `freeforcharity.org`, EIN `46-2471893`, phone
+  `520-222-8104`, or `@freeforcharity.org` email in `src/app/**` or
+  `src/components/**` is a hard error (footer platform credit excepted). This is
+  the piece that catches the legal-page blind spot `check:rebrand` doesn't scan.
+
+If both pass and you've done the SEO and delete-unused steps below, the rebrand
+is real — not skin-deep.
+
+## Inputs you need first
+
+Collect these before editing. Where you can't get an authoritative answer, do
+**not** guess — leave it out and flag it (see "Human-decision items"). A wrong
+EIN, jurisdiction, or donation term is worse than an omitted one.
+
+- Display name + tagline; SEO description + shorter OG/Twitter card description.
+- Production URL (custom domain, or the github.io fallback).
+- Contact email; security disclosure email (these can differ).
+- Social links (or leave `href: ''` — the footer filters empties).
+- Parent-org / fiscal-sponsor details if the site is a project of another org
+  (these drive `siteConfig.parentOrg`, not hardcoded strings).
+- Legal/entity facts **only if authoritative**: legal name, EIN, governing-law
+  state, mailing address, phone, whether the org solicits donations.
+
+## Procedure
+
+### 1. Central config — `src/lib/site.config.ts`
+
+Set every FFC default `npm run check:rebrand` reports: `name`, `tagline`,
+`description`, `shortDescription`, `url` (bare origin, `https://`, no trailing
+slash), `contactEmail`, `keywords`, `themeColor`, `social`, `parentOrg`,
+`guidestar`, `foundingDate`, and the analytics/GTM container in
+`src/lib/analytics.config.ts` (leaving FFC's GTM container sends your analytics
+to FFC). This is the single source of truth — don't duplicate these elsewhere.
+
+### 2. Domain + security.txt
+
+- `public/CNAME`: the custom domain, or delete the file for github.io-only.
+- `public/.well-known/security.txt` **and** `public/security.txt` (kept in sync
+  by the drift checker): `Contact:` = security email, `Canonical:`/`Policy:`/
+  `Acknowledgments:` = new URL, `Expires:` ≥ 12 months out.
+
+### 3. Legal / policy pages — enumerate ALL of them
+
+This is the step every shallow rebrand skips. Under `src/app/`, each has its own
+`page.tsx` with hardcoded org name, URLs, emails, and sometimes phone/EIN/
+jurisdiction:
+
+- `privacy-policy/` · `terms-of-service/` · `cookie-policy/`
+- `vulnerability-disclosure-policy/` · `security-acknowledgements/`
+- `donation-policy/` (and any variant) — see delete-unused.
+
+For each: fix the `metadata` (bare `title`, org-correct `description`, add
+`alternates.canonical`), then the body — org name, `freeforcharity.org` → new
+domain, contact emails → the org's, and remove FFC's phone/DPO name. Align the
+vulnerability-disclosure contact with `security.txt`. **Have the org's counsel
+review legal text before it goes live.**
+
+### 4. Delete unused demo content — don't just edit it
+
+The template ships demo sections and data a given org may not use. If a component
+isn't imported by `src/app/home-page/index.tsx` (or anywhere), it's dead — delete
+it and its test rather than leaving FFC content in the tree:
+
+- `src/components/home-page/*` sections not rendered on the home page.
+- `src/data/{team,testimonials,faqs}` if nothing imports them.
+- Donation pages if the org doesn't solicit donations — and remove their entries
+  from `src/app/sitemap.ts` and any Terms clause referencing a "Donation Policy"
+  so no dangling reference remains.
+
+Keep brand-neutral, reusable UI primitives (cards, buttons) even if unused.
+
+### 5. Per-page SEO — the invisible regressions
+
+- **Canonicals**: never set `alternates.canonical` on the root layout (App Router
+  inherits it into every route → all pages canonicalize to `/`). Set it per page:
+  home in `page.tsx`, `/articles`, each article via `generateMetadata`, every
+  policy page.
+- **Titles**: policy `title`s must be the bare page name so the layout template
+  supplies the brand — not `'… | Free For Charity'`, which double-brands.
+- **Article/detail pages**: give them their own `openGraph`/`twitter` metadata
+  and `Article` JSON-LD instead of inheriting the homepage card.
+
+### 6. Assets, footer, repo metadata
+
+- Swap `public/Images/` + `public/Svgs/`, keeping filenames so the LCP preload
+  and manifest icons still resolve. Always reference via `assetPath()`.
+- Footer: the parent-org / platform credit is config-driven via
+  `siteConfig.parentOrg` — set it (or clear it), don't hardcode. If you add a
+  hardcoded "Built with Free For Charity" credit line, it's the one allowlisted
+  identity exception.
+- `README.md`, `CITATION.cff`, `.github/FUNDING.yml`, repo description/topics.
+
+### 7. Human-decision items — ask, don't guess
+
+Surface these to the org rather than inventing values:
+
+- **EIN** and 501(c)(3) status (or the fiscal sponsor / parent org's).
+- **Governing-law jurisdiction** in the Terms (the template's is FFC's state).
+- **Donations**: does the org solicit them, and under which entity? Decides
+  whether donation pages are kept-and-rebranded or deleted.
+
+### 8. Verify — mandatory, in order
+
+```
+npm run format
+npm run lint
+npm run check:rebrand   # advisory: config/data defaults still present
+npm run check:drift     # ENFORCED: includes the brand-identity gate
+npm test
+npm run build
+npm run test:e2e
+```
+
+Then a belt-and-suspenders grep for surfaces the gate doesn't scan:
+
+```
+grep -rniE 'free ?for ?charity|freeforcharity\.org|46-?2471893|520[-. ]?222[-. ]?8104' src/ public/ \
+  | grep -v 'Built with Free For Charity'
+```
+
+And spot-check the built output in `out/`: policy `<title>`s, per-page
+`<link rel="canonical">`, and article `Article` JSON-LD.
+
+### 9. PR
+
+Open a PR listing every file changed, the `check:drift` + `check:rebrand`
+output, confirmation that legal pages were reviewed by counsel, the production
+URL, and an explicit **Decisions** section for every Human-decision item you
+omitted or defaulted.
+
+## Anti-patterns (all observed in real rebrands)
+
+- Rebranding the homepage and calling it done — the legal pages are the trap.
+- Trusting `check:rebrand` alone — it's advisory and doesn't scan the rendered
+  legal pages; `check:drift`'s identity gate does, and it blocks.
+- Editing demo data you should have deleted.
+- Guessing an EIN, jurisdiction, or donation terms to fill a blank.
+- Blanket-bumping a dependency to fix an advisory without checking it stays
+  within the CI Node version's supported range (e.g. undici 8 needs Node 22).

--- a/.github/ISSUE_TEMPLATE/rebrand-template.md
+++ b/.github/ISSUE_TEMPLATE/rebrand-template.md
@@ -440,27 +440,48 @@ Before submitting this issue, verify you have:
 
 ### Step 1: Assign Text-Based Updates to Copilot
 
-Copy and paste this template into a comment on this issue, filling in the values from above:
+> **Why this is a full checklist, not "replace all Free For Charity":** a naive
+> find-and-replace on the homepage leaves the **legal pages, deep routes, and
+> per-page SEO metadata** still branded as Free For Charity — and lint, build,
+> and tests all pass anyway. The steps below close those gaps. The agent should
+> follow the repo's **`rebrand` skill** (`.claude/skills/rebrand/SKILL.md`),
+> which encodes this in detail.
+
+Copy this into a comment on the issue, filling in the values from above:
 
 ```
-@copilot, based on the information provided in this issue, please update the repository:
+@copilot, follow the repository's `rebrand` skill and this issue to rebrand the site. Do ALL of the following, then run the verification step and paste its output back:
 
-1. Replace all instances of "Free For Charity" with "[Your Organization Name]"
-2. Replace all instances of "46-2471893" with "[Your EIN]"
-3. Replace all instances of "ffcworkingsite1.org" with "[your-domain.org]"
-4. Update CODEOWNERS file to list: @[username1], @[username2], @[username3]
-5. Update NEXT_PUBLIC_BASE_PATH in .github/workflows/deploy.yml and .github/workflows/lighthouse.yml to /[your-repo-name]
-6. Update all social media links in footer component to:
-   - Facebook: [your-facebook-url]
-   - Twitter: [your-twitter-url]
-   - LinkedIn: [your-linkedin-url]
-7. Update team member data in src/data/team/ with the board member information provided above
-8. Update FAQ data in src/data/faqs/ with the FAQ content provided above
-9. Update testimonial data in src/data/testimonials/ with the testimonial content provided above
-10. Update contact information (email, phone, addresses) throughout the codebase with the contact details provided above
+IDENTITY & CONFIG
+1. Set every field in src/lib/site.config.ts (name, tagline, description, shortDescription, url, contactEmail, keywords, themeColor, social, parentOrg, guidestar, foundingDate) and the GTM container in src/lib/analytics.config.ts — this is the single source of truth. `npm run check:rebrand` lists exactly which FFC defaults remain.
+2. Replace all instances of "ffcworkingsite1.org" with "[your-domain.org]" and update public/CNAME (or delete it for github.io-only).
+3. Update public/.well-known/security.txt AND public/security.txt: Contact = [security email], Canonical/Policy/Acknowledgments = new URL, Expires >= 12 months out.
+4. Update CODEOWNERS to: @[username1], @[username2], @[username3]; set NEXT_PUBLIC_BASE_PATH in deploy.yml/lighthouse.yml (empty for custom domain, /[repo] for github.io).
+
+LEGAL PAGES — do every one of these, metadata + body (org name, freeforcharity.org URLs, contact emails, phone, DPO name):
+5. src/app/{privacy-policy,terms-of-service,cookie-policy,vulnerability-disclosure-policy,security-acknowledgements}/page.tsx
+6. Give each a bare <title> and its own alternates.canonical. Align the vulnerability-disclosure contact with security.txt.
+7. Replace "46-2471893" (EIN) and "520-222-8104" (phone) everywhere with the org's — or remove if not provided. Do NOT invent an EIN, governing-law state, or donation terms; leave them for the org to confirm.
+
+DELETE UNUSED TEMPLATE CONTENT (don't just edit it):
+8. Delete any src/components/home-page/* section not imported by src/app/home-page/index.tsx, plus its test.
+9. Delete src/data/{team,testimonials,faqs} if nothing imports them; delete donation pages if the org doesn't solicit donations, and remove their src/app/sitemap.ts entries + any Terms "Donation Policy" reference.
+
+SEO:
+10. Do NOT set alternates.canonical on the root layout. Add per-page canonicals (home, /articles, each article via generateMetadata). Give article pages their own OpenGraph/Twitter + Article JSON-LD.
+
+CONTENT & METADATA:
+11. Social links, footer (parent-org credit via siteConfig.parentOrg), README.md, CITATION.cff, .github/FUNDING.yml, repo description/topics.
+
+VERIFY (paste output): npm run format && npm run lint && npm run check:rebrand && npm run check:drift && npm test && npm run build
 ```
 
-Copilot will handle all text-based find-and-replace operations automatically. **Estimated time: 5-10 minutes**
+`check:drift` includes a **brand-identity gate** that fails if any Free For
+Charity name, `freeforcharity.org` URL, EIN, phone, or `@freeforcharity.org`
+email is left in `src/app/**` or `src/components/**` (footer credit excepted) —
+the enforced complement to the advisory `check:rebrand` config/data checklist.
+If both pass, the rebrand is complete rather than skin-deep. **Estimated time:
+10-20 minutes.**
 
 ### Step 2: Manual File Uploads (Cannot be Automated)
 

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -12,6 +12,11 @@
  *     or public files after a child site rebrands.
  *  5. Two CSPs (public/_headers and src/app/layout.tsx meta tag) drifting
  *     out of sync on third-party origins.
+ *  6. Leftover Free For Charity brand identity (org name, freeforcharity.org
+ *     URLs, EIN, phone, @freeforcharity.org emails) in rendered pages/
+ *     components after a child site rebrands — the footer platform-credit
+ *     attribution is the one allowlisted exception. This is the enforced
+ *     complement to the advisory `npm run check:rebrand` config/data checklist.
  *
  * Run: `node scripts/check-drift.mjs` or `npm run check:drift`.
  * Always resolves paths relative to the repo root, so it works regardless
@@ -448,12 +453,86 @@ async function checkSecurityTxtSync() {
   }
 }
 
+// The template's own identity. A child site is considered "rebranded" once
+// siteConfig.name has been changed away from this default, at which point any
+// leftover FFC identity in rendered pages is a real drift bug. On the template
+// itself (name unchanged) this gate stays dormant, so it never fails template PRs.
+const TEMPLATE_ORG_NAME = 'Free For Charity'
+
+// Patterns that identify the Free For Charity organization specifically.
+// Safe to hard-fail on once a site has rebranded — none has a legitimate use in
+// a child site's own rendered pages. FFC references a child legitimately keeps
+// (e.g. a parent-org credit) live in src/lib/site.config.ts via siteConfig, not
+// as literals in src/app or src/components, so they are out of this scan's scope.
+const FFC_IDENTITY_PATTERNS = [
+  { re: /Free For Charity|Free for Charity/, label: 'the template org name "Free For Charity"' },
+  { re: /freeforcharity\.org/i, label: 'a freeforcharity.org URL' },
+  { re: /46-?2471893/, label: "Free For Charity's EIN (46-2471893)" },
+  { re: /520[\s.-]?222[\s.-]?8104/, label: "Free For Charity's phone number (520-222-8104)" },
+  { re: /[A-Za-z0-9._%+-]+@freeforcharity\.org/i, label: 'a @freeforcharity.org email address' },
+]
+
+// A child site that customizes its footer with a hardcoded "Built with Free For
+// Charity" platform credit may keep it. Allow ONLY those two specific lines (the
+// credit text and the exact attribution href) so any other freeforcharity.org
+// URL — or an EIN, phone, or email — is still flagged even inside the footer.
+function isAllowedIdentityLine(relPath, line) {
+  const normalized = relPath.split(sep).join('/')
+  if (normalized !== 'src/components/footer/index.tsx') return false
+  return (
+    /Built with Free For Charity/.test(line) || /href="https:\/\/freeforcharity\.org"/i.test(line)
+  )
+}
+
+async function checkBrandIdentity() {
+  const cfgPath = join(SRC_DIR, 'lib', 'site.config.ts')
+  let name = null
+  try {
+    const cfg = await readFile(cfgPath, 'utf8')
+    const m = cfg.match(/name:\s*['"]([^'"]+)['"]/)
+    name = m ? m[1] : null
+  } catch {
+    return // missing config handled in checkSiteConfigExists
+  }
+  // Dormant on the upstream template itself: FFC identity is correct there.
+  if (!name || name === TEMPLATE_ORG_NAME) return
+
+  const trees = [join(SRC_DIR, 'app'), join(SRC_DIR, 'components')]
+  const files = []
+  for (const tree of trees) {
+    files.push(...(await walk(tree, (n) => /\.(tsx?|jsx?)$/.test(n))))
+  }
+  for (const full of files) {
+    const rel = relative(ROOT, full)
+    let body
+    try {
+      body = await readFile(full, 'utf8')
+    } catch {
+      continue
+    }
+    const lines = body.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (isAllowedIdentityLine(rel, line)) continue
+      for (const p of FFC_IDENTITY_PATTERNS) {
+        if (p.re.test(line)) {
+          errors.push(
+            `${rel}:${i + 1} still references ${p.label} after this site rebranded to "${name}". ` +
+              `Replace it with the new organization's details.`
+          )
+        }
+      }
+    }
+  }
+}
+
 await checkSiteConfigExists()
 await checkSiteConfigUrl()
 await checkKebabCaseRoutes()
 await checkAssetPathUsage()
 await checkSecrets()
 await checkPlaceholderUrl()
+await checkBrandIdentity()
 await checkCspSync()
 await checkSecurityTxtSync()
 


### PR DESCRIPTION
## Description

Hardens the template's rebrand tooling so a fork can no longer ship a skin-deep rebrand — one whose homepage says the new org but whose **legal pages, deep routes, and metadata still belong to Free For Charity** — while lint, build, and tests all pass.

This came out of an actual rebrand (theafghanistanaffairs.org) where exactly that happened: the advisory `npm run check:rebrand` scans config/data but never the rendered pages, and `check:drift` only enforced the placeholder *domain*, not org *identity*. So the whole legal section shipped as "Free For Charity" and nothing failed.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] CI/CD or tooling change
- [x] Documentation update

## Related Issue(s)

N/A — process/tooling hardening. Companion changes were applied to the theafghanistanaffairs.org fork.

## Changes Made

- **`scripts/check-drift.mjs` — new enforced brand-identity gate.** Once `siteConfig.name` differs from `Free For Charity`, any leftover `Free For Charity`, `freeforcharity.org`, EIN `46-2471893`, phone `520-222-8104`, or `@freeforcharity.org` email in `src/app/**` or `src/components/**` is a hard error. It:
  - **stays dormant on this template** (name unchanged), so it never fails template PRs;
  - allowlists **only** the footer's exact platform-credit line and attribution href;
  - is the enforced complement to the advisory `check:rebrand` config/data checklist.
- **`.claude/skills/rebrand/SKILL.md` — new skill.** The full ordered rebrand procedure: enumerate every legal page, delete-if-unused demo content, per-page SEO/canonicals, human-decision items (EIN, jurisdiction, donations), and mandatory verification against both `check:rebrand` and `check:drift`.
- **`.github/ISSUE_TEMPLATE/rebrand-template.md`** — replaced the thin `@copilot, replace all instances of "Free For Charity"` instruction with a complete ordered checklist (all legal pages, delete-if-unused, SEO, human-decision items) plus a verification step.
- **`.claude/agents/onboarding.md`** — enumerate all five legal pages, add delete-unused + per-page SEO guidance, the identity grep, and a reference to the new skill.

## Testing Performed

### Automated Testing

- [x] `node scripts/check-drift.mjs` on this template — passes (identity gate dormant while `name` is unchanged).
- [x] Verified the gate **fires** on all five patterns when a site is rebranded (probe on the downstream fork: each of name/URL/EIN/phone/email is flagged with file:line).
- [x] Verified the footer allowlist matches only the exact credit + href lines — any other `freeforcharity.org` URL, EIN, phone, or email in the footer is still flagged.
- [x] Ported files pass Prettier.

## Breaking Changes

None. The gate is dormant on this template and only activates on a rebranded fork; a fork that legitimately keeps the footer platform credit is allowlisted.

## Additional Notes

The identity gate deliberately scans only `src/app/**` and `src/components/**` (rendered surfaces). FFC references a fork legitimately keeps — e.g. a parent-org credit — live in `src/lib/site.config.ts` via `siteConfig.parentOrg`, which is out of scope by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ScVwVDmkj3nhCtQiiAgvD

---
_Generated by [Claude Code](https://claude.ai/code/session_013ScVwVDmkj3nhCtQiiAgvD)_