### PR TITLE
feat: widen brand-identity + placeholder scans and add docs-cleanup skill step

### DIFF
--- a/.claude/skills/rebrand/SKILL.md
+++ b/.claude/skills/rebrand/SKILL.md
@@ -104,6 +104,10 @@ Keep brand-neutral, reusable UI primitives (cards, buttons) even if unused.
   supplies the brand — not `'… | Free For Charity'`, which double-brands.
 - **Article/detail pages**: give them their own `openGraph`/`twitter` metadata
   and `Article` JSON-LD instead of inheriting the homepage card.
+- **Heading hierarchy**: the template's legal pages ship with broken headings —
+  e.g. every section as its own `<h1>`, or a page whose top heading is an `<h2>`.
+  Each page needs exactly one `<h1>` (the title) with a logical `h2`/`h3` nesting
+  and no skipped levels. Check every policy page.
 
 ### 6. Assets, footer, repo metadata
 
@@ -113,7 +117,36 @@ Keep brand-neutral, reusable UI primitives (cards, buttons) even if unused.
   `siteConfig.parentOrg` — set it (or clear it), don't hardcode. If you add a
   hardcoded "Built with Free For Charity" credit line, it's the one allowlisted
   identity exception.
-- `README.md`, `CITATION.cff`, `.github/FUNDING.yml`, repo description/topics.
+
+### 6b. Full docs & metadata cleanup — the whole repo, not just `src/`
+
+The rebrand is not done when the app is clean; a fork also inherits a pile of
+Markdown and config that still names the template's placeholder domain
+(`ffcworkingsite1.org`) and, in functional metadata, points at the template repo.
+Do a **repo-wide** sweep:
+
+```
+grep -rniE 'ffcworkingsite1\.org|46-?2471893|520[-. ]?222[-. ]?8104' . \
+  --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=out
+```
+
+- **Functional metadata (ships real data — must be correct):** `.github/FUNDING.yml`
+  (fix the domain and drop any `#donate` link if the site has no donate flow),
+  `CITATION.cff` (`url` + `repository-code`), `.github/ISSUE_TEMPLATE/config.yml`
+  (contact links — point at the fork's repo, not the template repo), `README.md`.
+  The drift checker scans these, so a stale value fails CI once rebranded.
+- **Instance-describing docs (replace the placeholder domain with the real one):**
+  `CONTRIBUTING.md`, `SUPPORT.md`, `SECURITY.md`, `DEPLOYMENT.md`,
+  `CLOUDFLARE_SETUP.md`, `THREAT-MODEL.md`, `ADOPTERS.md`, `ISSUE_RESOLUTION.md`,
+  `NAMING_CONVENTIONS.md`, `FACEBOOK_EVENTS_SETUP.md`, and any workflow comments.
+- **Template-authoring guides (leave the placeholder — it's the teaching example):**
+  `TEMPLATE_USAGE.md`, `TEMPLATE_SETUP_CHECKLIST.md`, `TEMPLATE_CUSTOMIZATION.md`,
+  `CONTENT_REPLACEMENT_GUIDE.md`, `.github/ISSUE_TEMPLATE/rebrand-template.md`, and
+  `scripts/check-drift.mjs` (the `PLACEHOLDER_HOST` detection constant).
+- **Stale doc references to deleted routes/components:** if you removed the
+  donation pages (step 4), scrub their mentions from `README.md` and any guide
+  so the docs match the shipped routes.
+- Update the GitHub **repo description and topics** (web UI).
 
 ### 7. Human-decision items — ask, don't guess
 

--- a/.claude/skills/rebrand/SKILL.md
+++ b/.claude/skills/rebrand/SKILL.md
@@ -136,9 +136,18 @@ grep -rniE 'ffcworkingsite1\.org|46-?2471893|520[-. ]?222[-. ]?8104' . \
   (contact links — point at the fork's repo, not the template repo), `README.md`.
   The drift checker scans these, so a stale value fails CI once rebranded.
 - **Instance-describing docs (replace the placeholder domain with the real one):**
-  `CONTRIBUTING.md`, `SUPPORT.md`, `SECURITY.md`, `DEPLOYMENT.md`,
-  `CLOUDFLARE_SETUP.md`, `THREAT-MODEL.md`, `ADOPTERS.md`, `ISSUE_RESOLUTION.md`,
-  `NAMING_CONVENTIONS.md`, `FACEBOOK_EVENTS_SETUP.md`, and any workflow comments.
+  `CONTRIBUTING.md`, `SECURITY.md`, `DEPLOYMENT.md`, `CLOUDFLARE_SETUP.md`,
+  `THREAT-MODEL.md`, `ISSUE_RESOLUTION.md`, `NAMING_CONVENTIONS.md`,
+  `FACEBOOK_EVENTS_SETUP.md`, and any workflow comments. Where these describe the
+  new site (deployment, production URL, threat model), also swap the org NAME,
+  not just the domain — a domain change with "Free For Charity" text left beside
+  it reads as a mismatch.
+- **Docs that describe Free For Charity the platform/org — NOT the placeholder:**
+  `SUPPORT.md` (FFC's hosting/domain/grant services, EIN, support email) and the
+  `ADOPTERS.md` Free For Charity entry describe the real FFC org. Their links go
+  to `freeforcharity.org` — do NOT swap them to the new domain (that would claim
+  the new org offers FFC's services). If a template placeholder appears there,
+  fix it to `freeforcharity.org`, not the new site.
 - **Template-authoring guides (leave the placeholder — it's the teaching example):**
   `TEMPLATE_USAGE.md`, `TEMPLATE_SETUP_CHECKLIST.md`, `TEMPLATE_CUSTOMIZATION.md`,
   `CONTENT_REPLACEMENT_GUIDE.md`, `.github/ISSUE_TEMPLATE/rebrand-template.md`, and

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -246,9 +246,19 @@ async function checkPlaceholderUrl() {
 
   // Walk every text source under src/ and public/ (plus a small set of
   // well-known config files at the repo root) for the placeholder host.
+  // The extra files below are functional metadata that ships real data (funding
+  // links, citation URL, issue-template contact links) — not template-authoring
+  // guides, which legitimately keep the placeholder as a "replace-me" example.
   const interestingExt = /\.(tsx?|jsx?|md|mdx|txt|json|yml|yaml|webmanifest)$|^_headers$|^CNAME$/
   const roots = [join(ROOT, 'src'), join(ROOT, 'public')]
-  const rootFiles = ['next.config.ts', 'package.json', 'README.md']
+  const rootFiles = [
+    'next.config.ts',
+    'package.json',
+    'README.md',
+    'CITATION.cff',
+    '.github/FUNDING.yml',
+    '.github/ISSUE_TEMPLATE/config.yml',
+  ]
   const candidates = []
   for (const root of roots) {
     candidates.push(...(await walk(root, (n) => interestingExt.test(n))))
@@ -497,11 +507,9 @@ async function checkBrandIdentity() {
   // Dormant on the upstream template itself: FFC identity is correct there.
   if (!name || name === TEMPLATE_ORG_NAME) return
 
-  const trees = [join(SRC_DIR, 'app'), join(SRC_DIR, 'components')]
-  const files = []
-  for (const tree of trees) {
-    files.push(...(await walk(tree, (n) => /\.(tsx?|jsx?)$/.test(n))))
-  }
+  // Scan the whole src/ tree (app, components, lib, data) — leftover FFC
+  // identity in config or data modules is just as wrong as in a page.
+  const files = await walk(SRC_DIR, (n) => /\.(tsx?|jsx?)$/.test(n))
   for (const full of files) {
     const rel = relative(ROOT, full)
     let body


### PR DESCRIPTION
## Description

Follow-up to the rebrand-tooling hardening, from a second review of a downstream fork (theafghanistanaffairs.org). Two gaps surfaced: the brand-identity gate scanned only `src/app`/`src/components` (so identity in `src/lib`/`src/data` slipped past), and the placeholder-URL scan skipped functional metadata files that ship real data (`FUNDING.yml`, `CITATION.cff`, issue-template `config.yml`) — which is how a stale `ffcworkingsite1.org` reached a rebranded fork's metadata.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] CI/CD or tooling change
- [x] Documentation update

## Changes Made

- **`scripts/check-drift.mjs`**
  - `checkBrandIdentity` now scans the **whole `src/` tree** (app, components, lib, data) instead of just `app`/`components`.
  - `checkPlaceholderUrl` adds `CITATION.cff`, `.github/FUNDING.yml`, and `.github/ISSUE_TEMPLATE/config.yml` to its scan set (functional metadata that ships real data — not template-authoring guides, which keep the placeholder).
  - Both scans **remain dormant on this template** (gated on `siteConfig.name` / a rebranded URL), so template PRs never fail.
- **`.claude/skills/rebrand/SKILL.md`**
  - New **repo-wide docs & metadata cleanup** step that categorizes files into functional metadata (must be correct — drift-enforced), instance-describing docs (replace the placeholder domain), and template-authoring guides (keep the placeholder as the teaching example).
  - New **heading-hierarchy** check for the legal pages (the template ships pages with multiple `<h1>`s / a missing `<h1>`).

## Testing Performed

- [x] `node scripts/check-drift.mjs` on this template — passes (both widened scans dormant while `name`/URL are the template defaults).
- [x] Verified downstream (on the rebranded fork) that the widened scans **fire**: FFC identity added to `src/lib` and a stale domain added to `CITATION.cff` are both flagged with file:line, then clean once removed.
- [x] Ported files pass Prettier.

## Breaking Changes

None — both scans are dormant on the un-rebranded template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ScVwVDmkj3nhCtQiiAgvD

---
_Generated by [Claude Code](https://claude.ai/code/session_013ScVwVDmkj3nhCtQiiAgvD)_