### PR TITLE
ci: enforce verify:build in the CI build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
         # E2E tests need to run against a build without basePath since the test server
         # (serve -s out) doesn't understand basePath routing
 
+      - name: Verify build output
+        # Fails the build if any indexable page is missing its single <h1> or a
+        # per-page canonical (invariants a rebrand often breaks in rendered HTML).
+        run: npm run verify:build
+
       - name: Check bundle size
         # Reuses the build above — fails if shipped JS exceeds the gzipped budget.
         run: npm run check:bundle


### PR DESCRIPTION
## Description

Wires the `verify:build` guardrail (added in #390) into the CI build job so it actually gates PRs, instead of being an opt-in local/skill step. Now the built-output invariants a rebrand most often breaks are enforced for every fork.

## Type of Change

- [x] CI/CD or tooling change

## Changes Made

- `.github/workflows/ci.yml`: added a **Verify build output** step immediately after the Next.js build, running `npm run verify:build`. It fails the job if any indexable page in `out/` lacks its single `<h1>` or a per-page `<link rel="canonical">`.

This complements the existing enforced gates — `check:drift` (source) and `check:bundle` — and the advisory `check:rebrand` (config/data).

## Testing Performed

- [x] `npm run build && npm run verify:build` on `main` — passes (8 pages, one `<h1>` + canonical each).
- [x] `verify:build` was previously verified to **fail** when a second `<h1>` is injected (see #390).
- [x] `ci.yml` parses as valid YAML.

## Breaking Changes

None for compliant pages. A fork whose rebrand breaks heading hierarchy or per-page canonicals will now see CI fail with a clear message — which is the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ScVwVDmkj3nhCtQiiAgvD

---
_Generated by [Claude Code](https://claude.ai/code/session_013ScVwVDmkj3nhCtQiiAgvD)_