### PR TITLE
feat: add permanent 'Supported by Free For Charity' footer attribution

### DIFF
--- a/.claude/skills/rebrand/SKILL.md
+++ b/.claude/skills/rebrand/SKILL.md
@@ -115,8 +115,14 @@ Keep brand-neutral, reusable UI primitives (cards, buttons) even if unused.
   and manifest icons still resolve. Always reference via `assetPath()`.
 - Footer: the parent-org / platform credit is config-driven via
   `siteConfig.parentOrg` — set it (or clear it), don't hardcode. If you add a
-  hardcoded "Built with Free For Charity" credit line, it's the one allowlisted
+  hardcoded "Built with Free For Charity" credit line, it's an allowlisted
   identity exception.
+- Footer attribution that is NOT a rebrand target: `siteConfig.supportedBy`
+  (the permanent "Supported by Free For Charity" bottom-bar clause and the
+  "Supported Charity Login" hub link) and the hardcoded "Free For Charity
+  Donation Policy" label. These are part of the FFC footer standard — leave
+  them exactly as shipped; `check:drift` and `check:rebrand` deliberately
+  exempt them.
 
 ### 6b. Full docs & metadata cleanup — the whole repo, not just `src/`
 

--- a/TEMPLATE_CUSTOMIZATION.md
+++ b/TEMPLATE_CUSTOMIZATION.md
@@ -14,25 +14,26 @@ is the **map** — what changes where, and why.
 truth for site-specific values. Update the `siteConfig` export with your
 charity's name, URL, contact email, social links, etc.
 
-| Property                      | Where it shows up                                                                           |
-| ----------------------------- | ------------------------------------------------------------------------------------------- |
-| `name`                        | `<title>`, OG/Twitter `site_name`, 404 page, error page, footer copyright, manifest         |
-| `tagline`                     | Default `<title>` and OG title                                                              |
-| `description`                 | `<meta description>` (long form for search engines), manifest fallback                      |
-| `shortDescription`            | OG / Twitter card description (tuned for social previews; falls back to `description`)      |
-| `url`                         | `metadataBase`, sitemap entries, robots `Sitemap:` line                                     |
-| `twitterHandle`               | Twitter card `site` attribute (the leading `@` is added automatically)                      |
-| `contactEmail`                | Footer e-mail link. `security.txt` has its own `Contact:` line — keep them in sync.         |
-| `keywords`                    | `<meta keywords>`                                                                           |
-| `themeColor`                  | Web manifest `theme_color` and `background_color`                                           |
-| `vulnerabilityDisclosurePath` | 404 page CTA, error page disclosure link                                                    |
-| `social`                      | Footer social-link rail (icon resolved by `label`: Facebook, X (Twitter), LinkedIn, GitHub) |
-| `ein`                         | Footer EIN display line                                                                     |
-| `phone`                       | Footer phone link (`phone.display` shown, `phone.tel` used for the `tel:` link)             |
-| `addresses`                   | Footer contact column (`addresses[].label` / `.lines` / `.mapUrl`)                          |
-| `guidestar`                   | Footer GuideStar/Candid seal links (`guidestar.profileUrl`, `guidestar.directProfileUrl`)   |
-| `parentOrg`                   | Footer "a project of" parent-org clause (omit for a standalone charity)                     |
-| `integrations`                | Zeffy donation embed, Idealist profile, SociableKit events widget, Microsoft Forms URL      |
+| Property                      | Where it shows up                                                                                                                                                                                                      |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                        | `<title>`, OG/Twitter `site_name`, 404 page, error page, footer copyright, manifest                                                                                                                                    |
+| `tagline`                     | Default `<title>` and OG title                                                                                                                                                                                         |
+| `description`                 | `<meta description>` (long form for search engines), manifest fallback                                                                                                                                                 |
+| `shortDescription`            | OG / Twitter card description (tuned for social previews; falls back to `description`)                                                                                                                                 |
+| `url`                         | `metadataBase`, sitemap entries, robots `Sitemap:` line                                                                                                                                                                |
+| `twitterHandle`               | Twitter card `site` attribute (the leading `@` is added automatically)                                                                                                                                                 |
+| `contactEmail`                | Footer e-mail link. `security.txt` has its own `Contact:` line — keep them in sync.                                                                                                                                    |
+| `keywords`                    | `<meta keywords>`                                                                                                                                                                                                      |
+| `themeColor`                  | Web manifest `theme_color` and `background_color`                                                                                                                                                                      |
+| `vulnerabilityDisclosurePath` | 404 page CTA, error page disclosure link                                                                                                                                                                               |
+| `social`                      | Footer social-link rail (icon resolved by `label`: Facebook, X (Twitter), LinkedIn, GitHub)                                                                                                                            |
+| `ein`                         | Footer EIN display line                                                                                                                                                                                                |
+| `phone`                       | Footer phone link (`phone.display` shown, `phone.tel` used for the `tel:` link)                                                                                                                                        |
+| `addresses`                   | Footer contact column (`addresses[].label` / `.lines` / `.mapUrl`)                                                                                                                                                     |
+| `guidestar`                   | Footer GuideStar/Candid seal links (`guidestar.profileUrl`, `guidestar.directProfileUrl`)                                                                                                                              |
+| `supportedBy`                 | Permanent "Supported by Free For Charity" bottom-bar attribution and "Supported Charity Login" hub link. Part of the FFC footer standard: required, always rendered — do **not** change or remove it when customizing. |
+| `parentOrg`                   | Footer "a project of" parent-org clause (omit for a standalone charity)                                                                                                                                                |
+| `integrations`                | Zeffy donation embed, Idealist profile, SociableKit events widget, Microsoft Forms URL                                                                                                                                 |
 
 ### Things `siteConfig` does NOT drive
 

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -70,6 +70,40 @@ describe('Footer component', () => {
     expect(telLink).toHaveTextContent(siteConfig.phone.display)
   })
 
+  it('always renders the permanent "Supported by" attribution in the bottom bar', () => {
+    render(<Footer />)
+    // FFC footer standard: the attribution renders unconditionally (it does
+    // not depend on the optional parentOrg), naming the supporting org and
+    // linking to its site.
+    const bottomBar = screen.getByText(/All Rights Are Reserved/)
+    expect(bottomBar).toHaveTextContent(`Supported by ${siteConfig.supportedBy.name}`)
+    const attributionLink = screen
+      .getAllByRole('link')
+      .find(
+        (link) =>
+          link.getAttribute('href') === siteConfig.supportedBy.url &&
+          link.textContent === siteConfig.supportedBy.name
+      )
+    expect(attributionLink).toBeDefined()
+  })
+
+  it('always renders the Supported Charity Login quick link to the hub', () => {
+    render(<Footer />)
+    const hubLink = screen.getByText('Supported Charity Login').closest('a')
+    expect(hubLink).toHaveAttribute('href', siteConfig.supportedBy.hubUrl)
+  })
+
+  it('keeps the FFC donation policy label hardcoded (not siteConfig.name-branded)', () => {
+    render(<Footer />)
+    // This page documents FFC's own donation policy, so its label must not
+    // pick up a fork's rebranded siteConfig.name.
+    const ffcPolicyLink = screen.getByText('Free For Charity Donation Policy').closest('a')
+    expect(ffcPolicyLink).toHaveAttribute('href', '/free-for-charity-donation-policy')
+    // The charity's own donation policy remains a separate entry.
+    const ownPolicyLink = screen.getByText('Donation Policy').closest('a')
+    expect(ownPolicyLink).toHaveAttribute('href', '/donation-policy')
+  })
+
   it('renders every configured office address with a maps link', () => {
     render(<Footer />)
     const links = screen.getAllByRole('link')

--- a/__tests__/lib/site.config.test.ts
+++ b/__tests__/lib/site.config.test.ts
@@ -1,5 +1,18 @@
 import { siteConfig, siteUrl, twitterSite, cardDescription } from '../../src/lib/site.config'
 
+describe('supportedBy (FFC footer standard)', () => {
+  // The permanent "Supported by" attribution is required on every FFC-supported
+  // charity site. These assertions guard against a fork (or refactor) removing
+  // or repointing it — the values are intentionally FFC's, forever.
+  it('is present and points at Free For Charity', () => {
+    expect(siteConfig.supportedBy).toEqual({
+      name: 'Free For Charity',
+      url: 'https://freeforcharity.org',
+      hubUrl: 'https://freeforcharity.org/hub/',
+    })
+  })
+})
+
 describe('siteUrl', () => {
   it('returns the base URL for "/"', () => {
     expect(siteUrl('/')).toBe(`${siteConfig.url}/`)

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -483,15 +483,30 @@ const FFC_IDENTITY_PATTERNS = [
 ]
 
 // A child site that customizes its footer with a hardcoded "Built with Free For
-// Charity" platform credit may keep it. Allow ONLY those two specific lines (the
-// credit text and the exact attribution href) so any other freeforcharity.org
-// URL — or an EIN, phone, or email — is still flagged even inside the footer.
+// Charity" platform credit may keep it. Allow ONLY those specific lines (the
+// credit text, the exact attribution href, and the FFC donation-policy label —
+// that page documents FFC's own policy, so its label intentionally keeps FFC's
+// name after a rebrand) so any other freeforcharity.org URL — or an EIN, phone,
+// or email — is still flagged even inside the footer.
 function isAllowedIdentityLine(relPath, line) {
   const normalized = relPath.split(sep).join('/')
   if (normalized !== 'src/components/footer/index.tsx') return false
   return (
-    /Built with Free For Charity/.test(line) || /href="https:\/\/freeforcharity\.org"/i.test(line)
+    /Built with Free For Charity/.test(line) ||
+    /href="https:\/\/freeforcharity\.org"/i.test(line) ||
+    /Free For Charity Donation Policy/.test(line)
   )
+}
+
+// siteConfig.supportedBy intentionally keeps Free For Charity's name and URL
+// forever: it is the permanent "Supported by" attribution required by the FFC
+// footer standard, not leftover branding. Blank exactly that block (preserving
+// newlines so reported line numbers stay accurate) before the identity scan,
+// so every OTHER FFC reference in site.config.ts is still flagged.
+function withoutSupportedByBlock(relPath, body) {
+  const normalized = relPath.split(sep).join('/')
+  if (normalized !== 'src/lib/site.config.ts') return body
+  return body.replace(/supportedBy:\s*\{[^}]*\}/g, (block) => block.replace(/[^\n]/g, ' '))
 }
 
 async function checkBrandIdentity() {
@@ -518,7 +533,7 @@ async function checkBrandIdentity() {
     } catch {
       continue
     }
-    const lines = body.split('\n')
+    const lines = withoutSupportedByBlock(rel, body).split('\n')
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
       if (isAllowedIdentityLine(rel, line)) continue

--- a/scripts/rebrand-check.mjs
+++ b/scripts/rebrand-check.mjs
@@ -82,6 +82,11 @@ async function checkSiteConfig() {
     flag('Organization identity', `${rel} is missing — restore it from the template`, rel)
     return
   }
+  // siteConfig.supportedBy intentionally keeps Free For Charity's name and URL
+  // forever — it is the permanent "Supported by" footer attribution required by
+  // the FFC footer standard, NOT a rebrand target. Drop that block before
+  // scanning so it never shows up (or fails --strict) as an unfinished rebrand.
+  const scanned = cfg.replace(/supportedBy:\s*\{[^}]*\}/g, '')
   const defaults = [
     ['Charity name still "Free For Charity"', 'Free For Charity'],
     ['Domain still ffcworkingsite1.org', 'ffcworkingsite1.org'],
@@ -98,7 +103,7 @@ async function checkSiteConfig() {
     ['Founding date still FFC 2014', "foundingDate: '2014'"],
   ]
   for (const [label, needle] of defaults) {
-    if (cfg.includes(needle)) flag('Organization identity', label, rel)
+    if (scanned.includes(needle)) flag('Organization identity', label, rel)
   }
 }
 

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -85,10 +85,10 @@ const Footer: React.FC = () => {
                 { name: 'Volunteer', href: '/#volunteer' },
                 { name: 'FAQ', href: '/#faq' },
                 { name: 'Team', href: '/#team' },
-                // Only shown when this site is a project of a parent org with a hub.
-                ...(siteConfig.parentOrg?.hubUrl
-                  ? [{ name: 'Supported Charity Login', href: siteConfig.parentOrg.hubUrl }]
-                  : []),
+                // FFC footer standard: every supported charity site links back
+                // to the supporting org's hub. Always rendered — keep this
+                // entry when customizing a fork.
+                { name: 'Supported Charity Login', href: siteConfig.supportedBy.hubUrl },
               ].map((link) => {
                 const isExternal = link.href.startsWith('http')
                 return (
@@ -113,7 +113,11 @@ const Footer: React.FC = () => {
               <ul className="space-y-1 text-sm lato-font">
                 {[
                   {
-                    name: `${siteConfig.name} Donation Policy`,
+                    // Hardcoded on purpose: this page documents FFC's OWN
+                    // donation policy, so the label must keep FFC's name even
+                    // after a fork rebrands siteConfig.name. The adjacent
+                    // '/donation-policy' entry is the charity's own policy.
+                    name: 'Free For Charity Donation Policy',
                     href: '/free-for-charity-donation-policy',
                   },
                   {
@@ -238,6 +242,15 @@ const Footer: React.FC = () => {
       <div className="mt-12 py-6 px-4 border-t border-gray-800 text-center text-[18px] font-[500] w-full aria-font">
         <p>
           © {currentYear} All Rights Are Reserved by {siteConfig.name} a US 501c3 Non Profit
+          {/* FFC footer standard: the permanent "Supported by" attribution.
+              Always rendered — do NOT remove or hide it when customizing. */}
+          {' | Supported by '}
+          <Link
+            href={siteConfig.supportedBy.url}
+            className="underline text-[#2EA3F2] hover:text-[#2EA3F2] transition-colors"
+          >
+            {siteConfig.supportedBy.name}
+          </Link>
           {siteConfig.parentOrg && (
             <>
               {' | A project of '}

--- a/src/lib/site.config.ts
+++ b/src/lib/site.config.ts
@@ -92,6 +92,16 @@ export type SiteConfig = {
   /** GuideStar / Candid transparency profile links shown in the footer. */
   guidestar: { profileUrl: string; directProfileUrl: string }
   /**
+   * Permanent attribution to the supporting organization (FFC). Drives the
+   * always-rendered "Supported by" clause in the footer bottom bar and the
+   * "Supported Charity Login" quick link (`hubUrl`). This is part of the FFC
+   * footer standard for every supported charity site: it is REQUIRED, always
+   * rendered, and NOT to be removed or repointed when customizing a fork.
+   * Distinct from `parentOrg` below, which covers genuine fiscal-sponsorship
+   * ("a project of") relationships.
+   */
+  supportedBy: { name: string; url: string; hubUrl: string }
+  /**
    * Parent / umbrella organization, when this site is "a project of" another
    * nonprofit. Omit for a standalone charity (the footer clause is hidden).
    */
@@ -162,6 +172,11 @@ export const siteConfig: SiteConfig = {
     profileUrl: 'https://www.guidestar.org/profile/46-2471893',
     directProfileUrl:
       'https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742',
+  },
+  supportedBy: {
+    name: 'Free For Charity',
+    url: 'https://freeforcharity.org',
+    hubUrl: 'https://freeforcharity.org/hub/',
   },
   parentOrg: {
     name: 'Free For Charity',

--- a/tests/copyright.spec.ts
+++ b/tests/copyright.spec.ts
@@ -33,6 +33,28 @@ test.describe('Footer Copyright Notice', () => {
     await expect(footerText).toContainText(testConfig.copyright.text)
   })
 
+  test('should display the permanent "Supported by" attribution', async ({ page }) => {
+    // FFC footer standard: every supported charity site carries a permanent
+    // "Supported by <org>" link in the bottom bar. Unlike the parent-org
+    // clause below, this is always rendered — it must never be skipped.
+    await page.goto('/')
+
+    // On the template itself the supporting org and the parent org are both
+    // FFC, so this href can appear twice. The "Supported by" clause renders
+    // first (before the optional "A project of" clause) — assert on it.
+    const attributionLink = page
+      .locator(
+        `footer p:has-text("${testConfig.copyright.searchText}") a[href="${testConfig.copyright.supportedByUrl}"]`
+      )
+      .first()
+
+    await expect(attributionLink).toBeVisible()
+    await expect(attributionLink).toContainText(testConfig.copyright.supportedByText)
+
+    const footerText = page.locator(`footer p:has-text("${testConfig.copyright.searchText}")`)
+    await expect(footerText).toContainText(`Supported by ${testConfig.copyright.supportedByText}`)
+  })
+
   test('should display link to organization website in copyright notice', async ({ page }) => {
     // The footer only renders the "A project of" parent-org link when a parent
     // org is configured. Skip this assertion for standalone charities.
@@ -41,10 +63,15 @@ test.describe('Footer Copyright Notice', () => {
     // Navigate to the homepage
     await page.goto('/')
 
-    // Find the link within the copyright notice
-    const copyrightLink = page.locator(
-      `footer p:has-text("${testConfig.copyright.searchText}") a[href="${testConfig.copyright.linkUrl}"]`
-    )
+    // Find the link within the copyright notice. On the template itself the
+    // parent org and the supporting org are both FFC, so the same href appears
+    // twice ("Supported by" first, then "A project of") — assert on the last
+    // match, which is the parent-org clause.
+    const copyrightLink = page
+      .locator(
+        `footer p:has-text("${testConfig.copyright.searchText}") a[href="${testConfig.copyright.linkUrl}"]`
+      )
+      .last()
 
     // Verify the link is visible
     await expect(copyrightLink).toBeVisible()

--- a/tests/test.config.ts
+++ b/tests/test.config.ts
@@ -83,6 +83,10 @@ export const testConfig = {
   copyright: {
     text: 'All Rights Are Reserved by Free For Charity a US 501c3 Non Profit',
     searchText: 'All Rights Are Reserved',
+    // The permanent "Supported by" attribution (FFC footer standard) — sourced
+    // from siteConfig.supportedBy, which is required and always rendered.
+    supportedByUrl: siteConfig.supportedBy.url,
+    supportedByText: siteConfig.supportedBy.name,
     // Sourced from siteConfig so the parent-org link expectations track the
     // footer (which now shows the org name, not the raw URL, as link text).
     linkUrl: siteConfig.parentOrg?.url ?? '',


### PR DESCRIPTION
## Summary

Every FFC-supported charity site must carry a standing "Supported by Free For Charity" attribution linking https://freeforcharity.org — part of the FFC footer standard that Gate-3 validation checks. Previously, ALL FFC attribution vanished when the optional `parentOrg` was omitted, and the config docs explicitly invite omitting it for standalone charities. "A project of" is also the wrong semantic for an independent 501(c)(3) that is *supported by* (not a project of) FFC.

- **`src/lib/site.config.ts`**: new REQUIRED `supportedBy: { name, url, hubUrl }` (Free For Charity / https://freeforcharity.org / https://freeforcharity.org/hub/), documented as permanent, always rendered, and not a rebrand target. `parentOrg` stays optional for genuine fiscal-sponsorship ("a project of") cases.
- **Footer bottom bar**: always renders `| Supported by <a>Free For Charity</a>` after the copyright clause; the conditional `| A project of <parentOrg>` clause follows it.
- **Quick Links**: `Supported Charity Login` now keys off `supportedBy.hubUrl` (always present) instead of `parentOrg?.hubUrl`.
- **Policy links**: the `/free-for-charity-donation-policy` entry's label is hardcoded to "Free For Charity Donation Policy" — it documents FFC's own policy, so it must not pick up a fork's rebranded `siteConfig.name` (the adjacent `/donation-policy` entry remains the charity's own).
- **`scripts/check-drift.mjs`**: extended the existing identity-scan exemption mechanism — the `supportedBy` block in `site.config.ts` and the FFC donation-policy label in the footer are allowed after a fork rebrands; every other FFC reference is still flagged.
- **`scripts/check-rebrand.mjs`**: the `supportedBy` block is excluded from the defaults scan so a fully rebranded fork passes `--strict` (it would otherwise deadlock on the permanent FFC strings).
- **Tests**: unit coverage (always-rendered attribution, hub quick link, hardcoded policy label, `supportedBy` contract) + a new always-on e2e assertion in `copyright.spec.ts`. On the template itself `supportedBy.url === parentOrg.url`, so the copyright-bar locators disambiguate with `.first()`/`.last()`.
- **Docs**: `TEMPLATE_CUSTOMIZATION.md` table row + rebrand skill note that `supportedBy` is not a rebrand target.

## Test plan

- [x] `npm run format` / `npm run lint` — clean
- [x] `npm run check:drift` — no drift on the template; simulated a rebranded fork (`name` changed) and confirmed the `supportedBy` block and the FFC donation-policy label are exempt while all other FFC references are still flagged
- [x] `npm run check:rebrand` — still exits 0 with the same 15-item checklist; `supportedBy` never appears as an unfinished rebrand
- [x] `npm test` — 33 suites / 145 tests pass (incl. new Footer + site.config tests)
- [x] `npm run build` — static export succeeds
- [x] `npm run test:e2e` — 81 passed, 1 skipped (pre-existing conditional skip)

Refs FreeForCharity/FFC-Cloudflare-Automation#677 (footer attribution standard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)