### PR TITLE
feat: shared SiteConfig contract guard (schema + CI check)

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -37,3 +37,9 @@ jobs:
 
       - name: Run drift check
         run: node scripts/check-drift.mjs
+
+      # Validates src/lib/site.config.ts against the shared cross-template
+      # SiteConfig contract (schema/site-config.schema.json, kept identical
+      # in FFC-IN-FFC_Single_Page_Template and FFC-IN-Footer_Only_Template).
+      - name: Run shared SiteConfig contract check
+        run: node scripts/check-site-config.mjs

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "check:drift": "node scripts/check-drift.mjs",
+    "check:site-config": "node scripts/check-site-config.mjs",
     "check:rebrand": "node scripts/rebrand-check.mjs",
     "verify:build": "node scripts/verify-build.mjs",
     "check:bundle": "node scripts/check-bundle-size.mjs",

--- a/schema/site-config.schema.json
+++ b/schema/site-config.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://freeforcharity.org/schemas/site-config.schema.json",
+  "$comment": "This file must stay identical in FFC-IN-FFC_Single_Page_Template and FFC-IN-Footer_Only_Template; CI validates the local config against it.",
+  "title": "FFC shared SiteConfig contract",
+  "description": "Shared core shape of the `siteConfig` object exported from src/lib/site.config.ts across the FFC website templates (FreeForCharity/FFC-Cloudflare-Automation#693). The `required` keys are the cross-template contract; `additionalProperties` stays true so each template can carry its own extras (e.g. `integrations`, `foundingDate`, `nonprofitStatus`).",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "name",
+    "ein",
+    "contactEmail",
+    "phone",
+    "addresses",
+    "guidestar",
+    "social",
+    "supportedBy"
+  ],
+  "properties": {
+    "name": { "type": "string", "minLength": 1 },
+    "tagline": { "type": "string" },
+    "description": { "type": "string" },
+    "shortDescription": { "type": "string" },
+    "url": { "type": "string", "minLength": 1 },
+    "twitterHandle": { "type": "string" },
+    "contactEmail": { "type": "string", "minLength": 1 },
+    "keywords": { "type": "array", "items": { "type": "string" } },
+    "themeColor": { "type": "string" },
+    "vulnerabilityDisclosurePath": { "type": "string" },
+    "ein": { "type": "string", "minLength": 1 },
+    "phone": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["display", "tel"],
+      "properties": {
+        "display": { "type": "string", "minLength": 1 },
+        "tel": { "type": "string", "minLength": 1 }
+      }
+    },
+    "addresses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["label", "lines", "mapUrl"],
+        "properties": {
+          "label": { "type": "string", "minLength": 1 },
+          "lines": { "type": "array", "items": { "type": "string" } },
+          "mapUrl": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "guidestar": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["profileUrl", "directProfileUrl"],
+      "properties": {
+        "profileUrl": { "type": "string", "minLength": 1 },
+        "directProfileUrl": { "type": "string", "minLength": 1 }
+      }
+    },
+    "social": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["label", "href"],
+        "properties": {
+          "label": { "type": "string", "minLength": 1 },
+          "href": { "type": "string" }
+        }
+      }
+    },
+    "supportedBy": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "url", "hubUrl"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "url": { "const": "https://freeforcharity.org" },
+        "hubUrl": { "type": "string", "minLength": 1 }
+      }
+    },
+    "parentOrg": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "url", "hubUrl"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "minLength": 1 },
+        "hubUrl": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/scripts/check-site-config.mjs
+++ b/scripts/check-site-config.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * FFC shared-SiteConfig drift guard.
+ *
+ * Validates the `siteConfig` object exported from src/lib/site.config.ts
+ * against the cross-template contract in schema/site-config.schema.json.
+ * That schema file must stay byte-for-byte identical in
+ * FFC-IN-FFC_Single_Page_Template and FFC-IN-Footer_Only_Template — it is
+ * the contract that keeps the two templates' SiteConfig shapes converged
+ * (FreeForCharity/FFC-Cloudflare-Automation#693).
+ *
+ * Zero-dependency by design: the drift workflow runs without `npm ci`, so
+ * instead of pulling in a TS loader or ajv, this script extracts the
+ * siteConfig object literal from the TypeScript source and evaluates it in
+ * an isolated `node:vm` context, then validates it with a minimal built-in
+ * checker covering exactly the JSON Schema subset the contract uses
+ * (type, required, properties, items, const, minLength). If the schema
+ * grows a keyword the checker does not know, the run fails loudly rather
+ * than silently skipping the rule.
+ *
+ * Run: `node scripts/check-site-config.mjs` or `npm run check:site-config`.
+ * Exits non-zero on any validation error.
+ */
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import vm from 'node:vm'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(SCRIPT_DIR, '..')
+const CONFIG_PATH = join(ROOT, 'src', 'lib', 'site.config.ts')
+const SCHEMA_PATH = join(ROOT, 'schema', 'site-config.schema.json')
+
+/**
+ * Extract the `export const siteConfig ... = { ... }` object literal from
+ * the TypeScript source. Scans for the matching closing brace while
+ * skipping string literals ('…', "…", `…`) and comments so braces inside
+ * them do not unbalance the count.
+ */
+function extractSiteConfigLiteral(source) {
+  const marker = /export const siteConfig\s*(?::\s*SiteConfig)?\s*=\s*\{/.exec(source)
+  if (!marker) {
+    throw new Error(
+      `Could not find "export const siteConfig ... = {" in ${CONFIG_PATH}. ` +
+        `If the export was renamed, update scripts/check-site-config.mjs to match.`
+    )
+  }
+  const start = marker.index + marker[0].length - 1
+  let depth = 0
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i]
+    const next = source[i + 1]
+    if (ch === '/' && next === '/') {
+      i = source.indexOf('\n', i)
+      if (i === -1) break
+      continue
+    }
+    if (ch === '/' && next === '*') {
+      const close = source.indexOf('*/', i + 2)
+      if (close === -1) break
+      i = close + 1
+      continue
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      for (i += 1; i < source.length; i++) {
+        if (source[i] === '\\') {
+          i += 1
+        } else if (source[i] === ch) {
+          break
+        }
+      }
+      continue
+    }
+    if (ch === '{') depth += 1
+    if (ch === '}') {
+      depth -= 1
+      if (depth === 0) return source.slice(start, i + 1)
+    }
+  }
+  throw new Error(`Unbalanced braces while extracting the siteConfig literal from ${CONFIG_PATH}.`)
+}
+
+const SUPPORTED_KEYWORDS = new Set([
+  '$schema',
+  '$id',
+  '$comment',
+  'title',
+  'description',
+  'type',
+  'required',
+  'properties',
+  'items',
+  'const',
+  'minLength',
+  'additionalProperties',
+])
+
+function typeOf(value) {
+  if (Array.isArray(value)) return 'array'
+  if (value === null) return 'null'
+  return typeof value
+}
+
+/** Minimal validator for the JSON Schema subset used by the contract. */
+function validate(schema, value, path, errors) {
+  for (const keyword of Object.keys(schema)) {
+    if (!SUPPORTED_KEYWORDS.has(keyword)) {
+      errors.push(
+        `${path}: schema uses unsupported keyword "${keyword}" — ` +
+          `extend the validator in scripts/check-site-config.mjs before using it.`
+      )
+    }
+  }
+  if (schema.const !== undefined && value !== schema.const) {
+    errors.push(
+      `${path}: must equal ${JSON.stringify(schema.const)} (got ${JSON.stringify(value)})`
+    )
+    return
+  }
+  if (schema.type !== undefined && typeOf(value) !== schema.type) {
+    errors.push(`${path}: expected ${schema.type}, got ${typeOf(value)}`)
+    return
+  }
+  if (schema.type === 'string' && schema.minLength !== undefined) {
+    if (value.length < schema.minLength) {
+      errors.push(`${path}: must be a non-empty string`)
+    }
+  }
+  if (schema.type === 'object') {
+    for (const key of schema.required ?? []) {
+      if (!(key in value)) {
+        errors.push(`${path}: missing required key "${key}"`)
+      }
+    }
+    for (const [key, subSchema] of Object.entries(schema.properties ?? {})) {
+      if (key in value) {
+        validate(subSchema, value[key], `${path}.${key}`, errors)
+      }
+    }
+  }
+  if (schema.type === 'array' && schema.items !== undefined) {
+    value.forEach((item, index) => {
+      validate(schema.items, item, `${path}[${index}]`, errors)
+    })
+  }
+}
+
+async function main() {
+  const [schemaBody, configSource] = await Promise.all([
+    readFile(SCHEMA_PATH, 'utf8'),
+    readFile(CONFIG_PATH, 'utf8'),
+  ])
+  const schema = JSON.parse(schemaBody)
+  const literal = extractSiteConfigLiteral(configSource)
+  let siteConfig
+  try {
+    siteConfig = vm.runInNewContext(`(${literal})`, Object.create(null), { timeout: 1000 })
+  } catch (error) {
+    throw new Error(
+      `Failed to evaluate the siteConfig object literal: ${error.message}. ` +
+        `The literal must be plain data (no imports, identifiers, or interpolation).`
+    )
+  }
+
+  const errors = []
+  validate(schema, siteConfig, 'siteConfig', errors)
+
+  if (errors.length > 0) {
+    console.error('SiteConfig contract check FAILED:\n')
+    for (const message of errors) console.error(`  ✗ ${message}`)
+    console.error(
+      '\nThe shared SiteConfig shape is defined in schema/site-config.schema.json,' +
+        '\nwhich must stay identical in FFC-IN-FFC_Single_Page_Template and' +
+        '\nFFC-IN-Footer_Only_Template. Fix src/lib/site.config.ts (or, for an' +
+        '\nintentional cross-template shape change, update the schema in BOTH repos).'
+    )
+    process.exit(1)
+  }
+
+  console.log('SiteConfig contract check passed: src/lib/site.config.ts matches the shared schema.')
+}
+
+main().catch((error) => {
+  console.error(`check-site-config: ${error.message}`)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Overnight block 4, Single-Page half (log: FreeForCharity/FFC-Cloudflare-Automation#697; Footer-Only half merged as FFC-IN-Footer_Only_Template#86). Recovered from the block agent's staged worktree and verified.

- schema/site-config.schema.json — the shared cross-template SiteConfig contract, **byte-identical** to the Footer_Only_Template copy (verified)
- scripts/check-site-config.mjs — validates src/lib/site.config.ts against the schema; npm script + drift-check workflow wiring
- Contract check and site.config tests pass locally

Refs FreeForCharity/FFC-Cloudflare-Automation#693 (drift guard) + #697 (overnight block 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)