### PR TITLE
fix(ci): advanced CodeQL setup + Lighthouse subpath staging

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+name: CodeQL
+
+# Advanced-setup CodeQL analysis. The 'Protect Main' ruleset requires CodeQL
+# results for every PR, but GitHub's DEFAULT setup never uploads analyses for
+# PR refs — so every PR needed a manual bypass merge (see #395). This
+# workflow analyzes PRs, merge-queue groups, and pushes to main so the
+# required code-scanning results always exist.
+#
+# Operator note (#395): if CodeQL DEFAULT setup is (re-)enabled in
+# Settings → Code security → CodeQL, GitHub rejects this workflow's analysis
+# upload with a 'default setup enabled' error. Default setup must be switched
+# OFF so this workflow takes over.
+
+on:
+  # Runs on all pull requests
+  pull_request:
+    branches: ['main']
+
+  # Runs in the merge queue (Protect Main uses merge_queue + code_scanning)
+  merge_group:
+
+  # Runs on pushes to main
+  push:
+    branches: ['main']
+
+  # Weekly scan to pick up newly released CodeQL queries
+  schedule:
+    - cron: '0 6 * * 1'
+
+  # Allows manual trigger from Actions tab
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Matches the languages the previous default setup scanned
+        language: ['javascript-typescript', 'actions']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -57,10 +57,36 @@ jobs:
         env:
           NEXT_PUBLIC_BASE_PATH: ${{ steps.basepath.outputs.value }}
 
+      - name: Stage site for Lighthouse
+        id: stage
+        # lighthouserc.json serves ./out at the domain root and audits
+        # root-relative URLs. That matches a custom-domain deploy, but a
+        # subpath build prefixes every asset URL with /<repo-name> — served
+        # from the root, all CSS/JS would 404 and Lighthouse would audit an
+        # unstyled skeleton page (bogus scores, e.g. tap-target failures from
+        # default user-agent styles). Nest the export under the same subpath
+        # the production Pages deploy uses and audit the subpath URLs instead.
+        # The page list is derived from lighthouserc.json (single source of
+        # truth) so it can't drift from the config.
+        run: |
+          base="${{ steps.basepath.outputs.value }}"
+          if [ -n "$base" ]; then
+            mkdir -p "_lhci-site${base}"
+            cp -r out/. "_lhci-site${base}/"
+            flags="--collect.staticDistDir=./_lhci-site"
+            pages=$(jq -r '.ci.collect.url[] | sub("^http://localhost/"; "")' lighthouserc.json)
+            for page in $pages; do
+              flags="$flags --collect.url=http://localhost${base}/${page}"
+            done
+            echo "flags=$flags" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Lighthouse CI
         run: |
           npm install -g @lhci/cli
-          lhci autorun
+          lhci autorun ${{ steps.stage.outputs.flags }}
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 


### PR DESCRIPTION
## Summary

Two CI fixes in one PR (overnight block 12):

### 1. Advanced-setup CodeQL workflow (fixes the merge-queue deadlock)
The **Protect Main** ruleset requires CodeQL analysis results, but CodeQL **default setup never uploads analyses for PR refs**, so every PR has needed a manual bypass merge (confirmed on #393/#394). This adds `.github/workflows/codeql.yml` (advanced setup, `github/codeql-action`) analyzing `javascript-typescript` + `actions` on:
- `pull_request` to main
- `merge_group` (Protect Main uses a merge queue)
- `push` to main
- weekly schedule (Mondays 06:00 UTC)
- `workflow_dispatch`

**Operator toggle required (see #395):** if CodeQL *default setup* is enabled under **Settings → Code security → CodeQL**, GitHub rejects the advanced workflow's analysis upload with a 'default setup enabled' error — switch default setup **OFF** so this workflow takes over. (As of this PR the API reports default setup `not-configured` on this repo, so the upload should succeed as-is.)

### 2. Lighthouse subpath blind-spot fix (ported from FreeForCharity/FFC-EX-catnipandcattitude.org#33)
`lighthouserc.json` serves `./out` at the domain root, but subpath (no-CNAME) builds prefix every asset URL with `/<repo-name>` — so Lighthouse was auditing an unstyled 404-asset skeleton and producing bogus scores. The new **Stage site for Lighthouse** step nests the export under `_lhci-site/<repo-name>` and audits the same URL structure the production Pages deploy uses. Adaptation vs Catnip: the audited page list is derived from `lighthouserc.json` (single source of truth) instead of a hand-synced copy.

## Test plan
- `npm run format:check` — pass
- `npm run lint` — pass
- `npm test` — 33 suites / 145 tests pass
- Build/E2E skipped: changes are workflow-file-only (no runtime surface)
- CI on this PR exercises the new CodeQL workflow end-to-end

Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight block 12); Fixes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)