### PR TITLE
fix: enforce additionalProperties in site-config guard + fork-PR-safe Lighthouse comments (block 8 r3)

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -163,7 +163,10 @@ jobs:
         # always() so the score breakdown still reaches the PR when an
         # error-level assertion (accessibility/SEO) fails the lhci step —
         # that's exactly when the author needs the per-page table.
-        if: always() && github.event_name == 'pull_request'
+        # Fork PRs get a read-only GITHUB_TOKEN, so createComment would 403
+        # and fail the whole run — skip the step there (scores remain in the
+        # workflow log and artifacts).
+        if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/github-script@v8
         with:
           script: |
@@ -306,15 +309,24 @@ jobs:
             comment += `${context.payload.repository.html_url}/actions/runs/${context.runId}) for in-depth analysis.\n\n`;
             comment += '📖 Learn more about [Lighthouse scoring](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring/)';
 
-            // Post comment on PR
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
-
-            console.log('Lighthouse results comment posted successfully');
+            // Post comment on PR. Never fail the workflow over a comment:
+            // a permissions hiccup (e.g. a repo-in-org token restriction, or
+            // a fork PR that slipped past the step-level guard) must not
+            // mask green Lighthouse results.
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+              console.log('Lighthouse results comment posted successfully');
+            } catch (error) {
+              core.notice(
+                `Could not post the Lighthouse results comment (${error.message}). ` +
+                'Scores are still available in the step log above and the workflow artifacts.'
+              );
+            }
             }
 
             await run();

--- a/__tests__/scripts/check-site-config.test.ts
+++ b/__tests__/scripts/check-site-config.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+/**
+ * Contract tests for scripts/check-site-config.mjs, the zero-dependency
+ * SiteConfig drift guard shared byte-for-byte between
+ * FFC-IN-FFC_Single_Page_Template and FFC-IN-Footer_Only_Template.
+ *
+ * The minimal validator is exercised by importing the module in a child
+ * node process (the script is ESM and must stay outside the jest/ts
+ * transform); the script itself is also run end-to-end against the repo's
+ * real config + schema.
+ */
+const root = join(__dirname, '..', '..')
+const script = join(root, 'scripts', 'check-site-config.mjs')
+
+/** Runs `m.validate(schema, value, 'cfg', errors)` in a child node process. */
+function validateInChild(schema: unknown, value: unknown): string[] {
+  const href = pathToFileURL(script).href
+  const out = execFileSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `const m = await import(${JSON.stringify(href)});` +
+        `const errors = [];` +
+        `m.validate(${JSON.stringify(schema)}, ${JSON.stringify(value)}, 'cfg', errors);` +
+        `process.stdout.write(JSON.stringify(errors))`,
+    ],
+    { encoding: 'utf8' }
+  )
+  return JSON.parse(out)
+}
+
+describe('check-site-config validator: additionalProperties', () => {
+  const closedSchema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['name'],
+    properties: { name: { type: 'string' } },
+  }
+
+  it('rejects unknown keys when additionalProperties is false', () => {
+    // Before this was implemented the keyword was whitelisted but ignored —
+    // a schema that closed the object would silently false-pass.
+    const errors = validateInChild(closedSchema, { name: 'x', rogue: 1 })
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('unknown key "rogue"')
+    expect(errors[0]).toContain('additionalProperties: false')
+  })
+
+  it('accepts declared keys when additionalProperties is false', () => {
+    expect(validateInChild(closedSchema, { name: 'x' })).toEqual([])
+  })
+
+  it('does not flag the keyword itself as unsupported (boolean forms)', () => {
+    for (const value of [true, false]) {
+      const errors = validateInChild(
+        { type: 'object', additionalProperties: value, properties: {} },
+        {}
+      )
+      expect(errors.filter((e) => e.includes('unsupported keyword'))).toEqual([])
+    }
+  })
+
+  it('leaves objects open when additionalProperties is true or omitted', () => {
+    expect(
+      validateInChild({ type: 'object', additionalProperties: true, properties: {} }, { extra: 1 })
+    ).toEqual([])
+    expect(validateInChild({ type: 'object', properties: {} }, { extra: 1 })).toEqual([])
+  })
+
+  it('fails loudly on the unimplemented sub-schema form instead of silently passing', () => {
+    const errors = validateInChild(
+      { type: 'object', additionalProperties: { type: 'string' }, properties: {} },
+      { extra: 'x' }
+    )
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('non-boolean "additionalProperties"')
+  })
+
+  it('applies the closed-object rule to nested objects', () => {
+    const schema = {
+      type: 'object',
+      properties: { social: closedSchema },
+    }
+    const errors = validateInChild(schema, { social: { name: 'x', rogue: 1 } })
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('cfg.social')
+  })
+})
+
+describe('check-site-config script (end to end)', () => {
+  it('passes against the real src/lib/site.config.ts and shared schema', () => {
+    const out = execFileSync(process.execPath, [script], { encoding: 'utf8' })
+    expect(out).toContain('SiteConfig contract check passed')
+  })
+})

--- a/scripts/check-site-config.mjs
+++ b/scripts/check-site-config.mjs
@@ -14,16 +14,18 @@
  * siteConfig object literal from the TypeScript source and evaluates it in
  * an isolated `node:vm` context, then validates it with a minimal built-in
  * checker covering exactly the JSON Schema subset the contract uses
- * (type, required, properties, items, const, minLength). If the schema
- * grows a keyword the checker does not know, the run fails loudly rather
- * than silently skipping the rule.
+ * (type, required, properties, items, const, minLength, and boolean
+ * additionalProperties). If the schema grows a keyword — or a keyword form,
+ * e.g. a sub-schema additionalProperties — the checker does not know, the
+ * run fails loudly rather than silently skipping the rule.
  *
  * Run: `node scripts/check-site-config.mjs` or `npm run check:site-config`.
  * Exits non-zero on any validation error.
  */
 import { readFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import process from 'node:process'
 import vm from 'node:vm'
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
@@ -80,7 +82,7 @@ function extractSiteConfigLiteral(source) {
   throw new Error(`Unbalanced braces while extracting the siteConfig literal from ${CONFIG_PATH}.`)
 }
 
-const SUPPORTED_KEYWORDS = new Set([
+export const SUPPORTED_KEYWORDS = new Set([
   '$schema',
   '$id',
   '$comment',
@@ -102,7 +104,7 @@ function typeOf(value) {
 }
 
 /** Minimal validator for the JSON Schema subset used by the contract. */
-function validate(schema, value, path, errors) {
+export function validate(schema, value, path, errors) {
   for (const keyword of Object.keys(schema)) {
     if (!SUPPORTED_KEYWORDS.has(keyword)) {
       errors.push(
@@ -136,6 +138,26 @@ function validate(schema, value, path, errors) {
       if (key in value) {
         validate(subSchema, value[key], `${path}.${key}`, errors)
       }
+    }
+    // `additionalProperties: false` closes the object: any key not declared
+    // in `properties` is an error. `true` (or omitted) leaves it open. A
+    // sub-schema form is NOT implemented — fail loudly rather than silently
+    // passing whatever the schema author intended to constrain.
+    if (schema.additionalProperties === false) {
+      const declared = new Set(Object.keys(schema.properties ?? {}))
+      for (const key of Object.keys(value)) {
+        if (!declared.has(key)) {
+          errors.push(
+            `${path}: unknown key "${key}" — the schema sets additionalProperties: false, ` +
+              `so every key must be declared in its "properties".`
+          )
+        }
+      }
+    } else if (schema.additionalProperties !== undefined && schema.additionalProperties !== true) {
+      errors.push(
+        `${path}: schema uses a non-boolean "additionalProperties" (sub-schema form) — ` +
+          `extend the validator in scripts/check-site-config.mjs before using it.`
+      )
     }
   }
   if (schema.type === 'array' && schema.items !== undefined) {
@@ -180,7 +202,10 @@ async function main() {
   console.log('SiteConfig contract check passed: src/lib/site.config.ts matches the shared schema.')
 }
 
-main().catch((error) => {
-  console.error(`check-site-config: ${error.message}`)
-  process.exit(1)
-})
+// Only run when executed directly (allows importing validate() in tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`check-site-config: ${error.message}`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (block 8 review fixes)

## Summary

- **`scripts/check-site-config.mjs`**: `additionalProperties` was whitelisted in `SUPPORTED_KEYWORDS` but never implemented — if the shared schema ever set it to `false`, unknown keys would silently false-pass. Now implemented: when `false`, any key not declared in `properties` is an error; `true`/omitted leaves the object open; the (unimplemented) sub-schema form fails loudly instead of being ignored. `validate()` is exported and `main()` gated on direct execution so the validator is unit-testable.
- **`.github/workflows/lighthouse.yml`**: the PR-comment step 403s on fork PRs (read-only `GITHUB_TOKEN`) and failed the whole run. The step is now skipped when `github.event.pull_request.head.repo.fork`, and `createComment` is wrapped in try/catch that emits a `core.notice` instead of failing — scores stay in the step log and workflow artifacts either way.

The same `check-site-config.mjs` fix is mirrored into FFC-IN-Footer_Only_Template (blob-identical file) in its own `fix/r3-guards` PR.

## Test plan

- `npm run format:check` + `npm run lint` — clean
- `npm run test` — 34 suites / **152 passed**, including new `__tests__/scripts/check-site-config.test.ts` (unknown-key rejection, open-object behavior, loud failure on sub-schema form, nested objects, end-to-end run)
- `npm run check:site-config` — passes against the real `src/lib/site.config.ts`
- `lighthouse.yml` YAML-parses; comment-step condition verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
