### PR TITLE
chore: bump Pages actions off deprecated Node 20 runtimes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           cache: 'npm'
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
@@ -89,7 +89,7 @@ jobs:
           NEXT_PUBLIC_BASE_PATH: ${{ steps.basepath.outputs.value }}
 
       - name: Upload artifact for Pages
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
       - name: Checkout (for smoke-check script)
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

GitHub removes Node 20 from Actions runners on **2026-09-16** (the default already flipped to Node 24 on 2026-06-16). Three actions pinned in `.github/workflows/deploy.yml` still run on the node20 runtime and would start failing after that date — and since this is a provisioning template, every site created from it inherits the broken workflow. This applies the fix from FreeForCharity/FFC-Cloudflare-Automation#421 to this template.

## Type of Change

- [x] CI/CD or tooling change

## Related Issue(s)

Relates to FreeForCharity/FFC-Cloudflare-Automation#421 (cross-repo tracking issue; this PR covers this template repo)

## Changes Made

- `actions/configure-pages`: v5 → v6 (node20 → node24)
- `actions/upload-pages-artifact`: v4 → v5 (v4 wraps node20 `upload-artifact@v4.6.2`; v5 wraps node24 `upload-artifact@v7`)
- `actions/deploy-pages`: v4 → v5 (node20 → node24)

Runtimes were verified from each action's `action.yml` `runs.using` at the target tag, not assumed. A sweep of all other workflows (`ci.yml`, `lighthouse.yml`, `security-audit.yml`, `drift-check.yml`, `uptime.yml`, `scorecard.yml`, `security-txt-expiry.yml`, `phantom-revert-guard.yml`) found no other node20-runtime actions — `checkout@v6`, `setup-node@v6`, `cache@v5`, `github-script@v8`, `upload-artifact@v7` are already node24, and `ossf/scorecard-action` is Docker-based. The resulting `deploy.yml` is byte-identical to the output of the idempotent sed fix shipped in the tracking issue.

## Screenshots (if applicable)

N/A — workflow-only change.

## Testing Performed

### Manual Testing

- [x] Verified the diff matches the tracking issue's ready-to-apply sed script output exactly (and that the script is idempotent)
- [x] Checked console for errors

### Automated Testing

- [x] `npm run lint` - All linting checks pass
- [x] `npm test` - All unit tests pass (152 passed, 34 suites)
- [x] `npm run build` - Build completes successfully (static export)
- [x] `npm run test:e2e` - All E2E tests pass (81 passed, 1 skipped)
- [x] `npm run format` and `npm run check:drift` also pass

### Accessibility

N/A — no UI change.

## Documentation

- [x] Code is self-documenting or includes comments where needed

## Breaking Changes

None / N/A — the deploy workflow's behavior is unchanged; only the actions' runtimes move to Node 24.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally
- [x] My commits follow the conventional commit format
- [x] I have rebased my branch on the latest main

## Additional Notes

The deploy jobs also pass `node-version: '20'` to `setup-node` (as do the other workflows). That is a separate concern from this issue — the runner keeps supporting installed toolchains, so those workflows won't break on 2026-09-16 — but Node 20 has been EOL since 2026-04-30, so bumping the toolchain to 22/24 may be worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd71UTPgnDjb4Vci4wJ5PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd71UTPgnDjb4Vci4wJ5PJ)_