### PR TITLE
fix(smoke): navigate on 'load', not 'networkidle' (false status-0 reds)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -281,10 +281,15 @@ jobs:
             page.setDefaultTimeout(45000);
             let resp = null;
             try {
-              resp = await page.goto(url, { waitUntil: 'networkidle' });
+              // 'load' fires deterministically; 'networkidle' never fires on pages
+              // with persistent analytics/embed traffic (GTM, social widgets), which
+              // times out goto and zeroes the status even though the page is fine.
+              resp = await page.goto(url, { waitUntil: 'load' });
             } catch (e) {
               console.error('navigation error:', e.message);
             }
+            // Best-effort settle for late-loading assets before the screenshot.
+            await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
             const status = resp ? resp.status() : 0;
             const title = await page.title().catch(() => '');
             const bodyText = await page.evaluate(() => document.body && document.body.innerText || '').catch(() => '');


### PR DESCRIPTION
## What & why

Post-Deploy Smoke's visual check navigates with `waitUntil: 'networkidle'`. On a site with persistent analytics/embed traffic (GTM, social widgets), networkidle **never fires**: `page.goto` times out (45s), `resp` stays `null`, and the engine fails with `Visual: page status 0 (expected 200)` even though the page is fully up (curl 200, every compliance probe passes).

First real hit: freedomrisingusa.org, run [29693783131](https://github.com/FreeForCharity/FFC-EX-freedomrisingusa.org/actions/runs/29693783131) — page renders, footer complete, complianceFailures `[]`, only the status-0 assert red.

## Fix

- `page.goto(url, { waitUntil: 'load' })` — deterministic, still a real navigation success signal.
- Best-effort `waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {})` before the screenshot so late assets still settle when they can.

## Test plan

- YAML parses (workflow visible in Actions after merge).
- Post-merge deploy run's smoke job goes green on this repo.
- Fleet resync tracked separately in the automation hub (agentic-os backlog) so all 62 repos pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)