### PR TITLE
fix(smoke): v3.1 — visual check waits for load, not networkidle

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -281,15 +281,14 @@ jobs:
             page.setDefaultTimeout(45000);
             let resp = null;
             try {
-              // 'load' fires deterministically; 'networkidle' never fires on pages
-              // with persistent analytics/embed traffic (GTM, social widgets), which
-              // times out goto and zeroes the status even though the page is fine.
+              // 'load', not 'networkidle': pages with live payment/analytics
+              // widgets (Stripe, Google Pay, Amplitude) beacon continuously and
+              // never reach network silence (found on freedomrisingusa.org).
               resp = await page.goto(url, { waitUntil: 'load' });
+              await page.waitForTimeout(1500); // let client-side UI (cookie banner) mount
             } catch (e) {
               console.error('navigation error:', e.message);
             }
-            // Best-effort settle for late-loading assets before the screenshot.
-            await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
             const status = resp ? resp.status() : 0;
             const title = await page.title().catch(() => '');
             const bodyText = await page.evaluate(() => document.body && document.body.innerText || '').catch(() => '');


### PR DESCRIPTION
v3.1: goto waits for load + settle (networkidle unreachable on widget-heavy pages). Refs FreeForCharity/FFC-Cloudflare-Automation#738.