### PR TITLE
fix(ci): include hidden files in Pages artifact so security.txt deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,10 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
+          # upload-pages-artifact@v5 defaults include-hidden-files to false,
+          # which excludes dot-entries (.well-known/, .nojekyll) from the tar
+          # and 404s the canonical RFC 9116 /.well-known/security.txt.
+          include-hidden-files: true
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
## Description

Primary change for this run: `actions/upload-pages-artifact@v5` defaults `include-hidden-files` to `false`, adding `--exclude=.[^/]*` to its tar and silently dropping every dot-entry in `out/` (`.well-known/`, `.nojekyll`). This template **ships `public/.well-known/security.txt`** and uses `upload-pages-artifact@v5`, so the canonical RFC 9116 path `/.well-known/security.txt` currently **404s** on this template and every fork built from it. The fix sets `include-hidden-files: true` on the upload step (tip commit `0674813`).

## ⚠️ Branch also carries pre-existing unmerged work

This session's designated branch (`claude/clever-babbage-cujmto`) already contained **19 commits of smoke-engine work (v2 → v3.4.1: dual-target smoke, tri-state donation detection, Zeffy embed checks, `uptime.yml` retirement)** with **no prior open/closed PR**. Per the queue rules I must not discard unmerged commits and must develop on the designated branch, so the `include-hidden-files` fix stacks on top of that work rather than on a fresh base. Reviewers may wish to split the smoke-engine commits into their own PR — flagging so the bundling is a deliberate, visible choice and not lost history.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD or tooling change

## Related Issue(s)

Refs FreeForCharity/FFC-Cloudflare-Automation#788

## Changes Made

- `.github/workflows/deploy.yml`: added `include-hidden-files: true` to the `actions/upload-pages-artifact@v5` step (this run's fix).
- Pre-existing on the branch: `.github/workflows/post-deploy-smoke.yml` (new smoke engine, +714), `.github/workflows/uptime.yml` removed (superseded by the smoke engine).

## Testing Performed

### Automated Testing

- [x] Repo pre-commit hook ran on my commit: `prettier --check` (pass), `eslint` (pass), `check:drift` (✅ no drift).
- [x] `deploy.yml` YAML parses cleanly.

Full deploy verification is post-merge: confirm `curl -sS -o /dev/null -w '%{http_code}' https://<site>/.well-known/security.txt` returns `200`. Reference fix proven live on FFC-EX-technologymonastery.org PR #58.

## Breaking Changes

None / N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCnCQbe66xbpecBMqGJsPu