### PR TITLE
feat: read donation scope from committed .github/smoke.config.json

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -298,6 +298,11 @@ jobs:
                 console.error(`::error::.github/smoke.config.json exists but is not valid JSON: ${e.message}`);
                 process.exit(1);
               }
+              const fileScope = String(fileConfig.donationScope || '').toLowerCase();
+              if (fileScope && !['charity', 'ffc-interim', 'none'].includes(fileScope)) {
+                console.error(`::error::.github/smoke.config.json donationScope "${fileConfig.donationScope}" is not one of charity|ffc-interim|none`);
+                process.exit(1);
+              }
             }
 
             const browser = await chromium.launch();
@@ -671,6 +676,14 @@ jobs:
               echo "::error::.github/smoke.config.json exists but is not valid JSON"
               exit 1
             fi
+            SCOPE=$(echo "$SCOPE" | tr '[:upper:]' '[:lower:]')
+            case "$SCOPE" in
+              '' | charity | ffc-interim | none) ;;
+              *)
+                echo "::error::.github/smoke.config.json donationScope \"$SCOPE\" is not one of charity|ffc-interim|none"
+                exit 1
+                ;;
+            esac
           fi
 
           # --- donation-migration (auto-detected, provider-based) ---

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -287,12 +287,18 @@ jobs:
             const requireCookieConsent = String(process.env.SMOKE_REQUIRE_COOKIE_CONSENT || 'true').toLowerCase() !== 'false';
             // Committed site declarations (.github/smoke.config.json) — the
             // repo-visible alternative to Actions variables. An explicitly-set
-            // variable still wins over the file.
+            // variable still wins over the file. A file that exists but does
+            // not parse is a hard error, not a silent fallback.
             let fileConfig = {};
-            try {
-              fileConfig = JSON.parse(require('fs').readFileSync(
-                process.env.GITHUB_WORKSPACE + '/.github/smoke.config.json', 'utf8'));
-            } catch { /* no committed config */ }
+            const smokeConfigPath = process.env.GITHUB_WORKSPACE + '/.github/smoke.config.json';
+            if (require('fs').existsSync(smokeConfigPath)) {
+              try {
+                fileConfig = JSON.parse(require('fs').readFileSync(smokeConfigPath, 'utf8'));
+              } catch (e) {
+                console.error(`::error::.github/smoke.config.json exists but is not valid JSON: ${e.message}`);
+                process.exit(1);
+              }
+            }
 
             const browser = await chromium.launch();
             const ctx = await browser.newContext({
@@ -658,9 +664,13 @@ jobs:
           REPO="${GITHUB_REPOSITORY}"
 
           # Committed declaration fallback: .github/smoke.config.json's
-          # donationScope applies when the SMOKE_DONATION_SCOPE variable is unset.
+          # donationScope applies when the SMOKE_DONATION_SCOPE variable is
+          # unset. A file that exists but does not parse is a hard error.
           if [ -z "${SCOPE:-}" ] && [ -f .github/smoke.config.json ]; then
-            SCOPE=$(jq -r '.donationScope // ""' .github/smoke.config.json 2>/dev/null || echo "")
+            if ! SCOPE=$(jq -r '.donationScope // ""' .github/smoke.config.json); then
+              echo "::error::.github/smoke.config.json exists but is not valid JSON"
+              exit 1
+            fi
           fi
 
           # --- donation-migration (auto-detected, provider-based) ---

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -259,6 +259,10 @@ jobs:
           #                 until replaced with the charity's own campaign
           #   none        - site intentionally has no donations (suppresses the
           #                 no-donation-capability failure)
+          # Preferred declaration: commit .github/smoke.config.json with
+          # {"donationScope": "none"} — repo-visible and PR-reviewable (e.g.
+          # for-profit FFC-EX sites like towing companies). The variable, when
+          # set, still overrides the committed file.
           SMOKE_DONATION_SCOPE: ${{ vars.SMOKE_DONATION_SCOPE }}
           # Legacy (v3.2): require at least one Zeffy iframe embed specifically.
           SMOKE_REQUIRE_DONATION_EMBED: ${{ vars.SMOKE_REQUIRE_DONATION_EMBED }}
@@ -281,6 +285,14 @@ jobs:
             const requiredLinks = (process.env.SMOKE_REQUIRED_FOOTER_LINKS || '/privacy-policy,/terms-of-service|/tos')
               .split(',').map(s => s.trim()).filter(Boolean);
             const requireCookieConsent = String(process.env.SMOKE_REQUIRE_COOKIE_CONSENT || 'true').toLowerCase() !== 'false';
+            // Committed site declarations (.github/smoke.config.json) — the
+            // repo-visible alternative to Actions variables. An explicitly-set
+            // variable still wins over the file.
+            let fileConfig = {};
+            try {
+              fileConfig = JSON.parse(require('fs').readFileSync(
+                process.env.GITHUB_WORKSPACE + '/.github/smoke.config.json', 'utf8'));
+            } catch { /* no committed config */ }
 
             const browser = await chromium.launch();
             const ctx = await browser.newContext({
@@ -448,7 +460,7 @@ jobs:
 
             // Donation assertions — first-class: a charity site must never
             // silently lose its donation capability.
-            const donationScope = String(process.env.SMOKE_DONATION_SCOPE || '').toLowerCase();
+            const donationScope = String(process.env.SMOKE_DONATION_SCOPE || fileConfig.donationScope || '').toLowerCase();
             const requireDonation = String(process.env.SMOKE_REQUIRE_DONATION_EMBED || '').toLowerCase() === 'true';
             const donationChecks = [];
             if (requireDonation && donationEmbeds.length === 0) {
@@ -460,7 +472,7 @@ jobs:
             //   Zeffy present                -> PASS (charity or ffc-interim per scope)
             const isApex = String(process.env.SMOKE_MODE || '') !== 'default';
             if (isApex && !placeholder && donationSurfaces.length === 0 && donationScope !== 'none') {
-              complianceFailures.push('No donation capability detected (no Zeffy, PayPal, or other donation provider found). Wire a Zeffy campaign, or set SMOKE_DONATION_SCOPE=none only if this site intentionally takes no donations.');
+              complianceFailures.push('No donation capability detected (no Zeffy, PayPal, or other donation provider found). Wire a Zeffy campaign, or declare {"donationScope": "none"} in .github/smoke.config.json (or set SMOKE_DONATION_SCOPE=none) only if this site intentionally takes no donations.');
             }
             // Every surface must be reachable, whatever the provider.
             for (const s of donationSurfaces) {
@@ -644,6 +656,12 @@ jobs:
         run: |
           set -euo pipefail
           REPO="${GITHUB_REPOSITORY}"
+
+          # Committed declaration fallback: .github/smoke.config.json's
+          # donationScope applies when the SMOKE_DONATION_SCOPE variable is unset.
+          if [ -z "${SCOPE:-}" ] && [ -f .github/smoke.config.json ]; then
+            SCOPE=$(jq -r '.donationScope // ""' .github/smoke.config.json 2>/dev/null || echo "")
+          fi
 
           # --- donation-migration (auto-detected, provider-based) ---
           nonpref="false"; providers=""

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -298,6 +298,10 @@ jobs:
                 console.error(`::error::.github/smoke.config.json exists but is not valid JSON: ${e.message}`);
                 process.exit(1);
               }
+              if (fileConfig === null || typeof fileConfig !== 'object' || Array.isArray(fileConfig)) {
+                console.error('::error::.github/smoke.config.json must contain a JSON object');
+                process.exit(1);
+              }
               const fileScope = String(fileConfig.donationScope || '').toLowerCase();
               if (fileScope && !['charity', 'ffc-interim', 'none'].includes(fileScope)) {
                 console.error(`::error::.github/smoke.config.json donationScope "${fileConfig.donationScope}" is not one of charity|ffc-interim|none`);

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -738,9 +738,9 @@ jobs:
                 "That is the intended interim state — donations keep working — but it must stay visible until replaced:" \
                 "1. Create the charity's own Zeffy campaign/form." \
                 "2. Swap the embed/button URLs in the site." \
-                "3. Set the repo variable SMOKE_DONATION_SCOPE=charity." \
+                "3. Declare the scope as charity — set donationScope in the committed .github/smoke.config.json (preferred) or the SMOKE_DONATION_SCOPE repo variable." \
                 "" \
-                "This issue is auto-managed by the smoke engine: it stays open while SMOKE_DONATION_SCOPE=ffc-interim and auto-closes once the scope changes.")
+                "This issue is auto-managed by the smoke engine: it stays open while the declared donation scope is ffc-interim and auto-closes once the scope changes.")
               gh api "repos/${REPO}/issues" --method POST \
                 -f title="Donations run on an FFC campaign — replace with a charity-specific Zeffy campaign" \
                 -f body="$body" \
@@ -752,7 +752,7 @@ jobs:
           else
             if [ -n "$existing" ]; then
               gh api "repos/${REPO}/issues/${existing}/comments" --method POST \
-                -f body="✅ SMOKE_DONATION_SCOPE is no longer ffc-interim — charity-specific donations in place. Auto-closing." >/dev/null
+                -f body="✅ The declared donation scope is no longer ffc-interim — charity-specific donations in place. Auto-closing." >/dev/null
               gh api -X PATCH "repos/${REPO}/issues/${existing}" -f state=closed >/dev/null
               echo "Closed donation-interim issue #${existing}"
             fi

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -295,14 +295,14 @@ jobs:
               try {
                 fileConfig = JSON.parse(require('fs').readFileSync(smokeConfigPath, 'utf8'));
               } catch (e) {
-                console.error(`::error::.github/smoke.config.json exists but is not valid JSON: ${e.message}`);
+                console.error(`::error::.github/smoke.config.json exists but is not valid JSON: ${e instanceof Error ? e.message : String(e)}`);
                 process.exit(1);
               }
               if (fileConfig === null || typeof fileConfig !== 'object' || Array.isArray(fileConfig)) {
                 console.error('::error::.github/smoke.config.json must contain a JSON object');
                 process.exit(1);
               }
-              const fileScope = String(fileConfig.donationScope || '').toLowerCase();
+              const fileScope = String(fileConfig.donationScope || '').trim().toLowerCase();
               if (fileScope && !['charity', 'ffc-interim', 'none'].includes(fileScope)) {
                 console.error(`::error::.github/smoke.config.json donationScope "${fileConfig.donationScope}" is not one of charity|ffc-interim|none`);
                 process.exit(1);
@@ -475,7 +475,7 @@ jobs:
 
             // Donation assertions — first-class: a charity site must never
             // silently lose its donation capability.
-            const donationScope = String(process.env.SMOKE_DONATION_SCOPE || fileConfig.donationScope || '').toLowerCase();
+            const donationScope = String(process.env.SMOKE_DONATION_SCOPE || fileConfig.donationScope || '').trim().toLowerCase();
             const requireDonation = String(process.env.SMOKE_REQUIRE_DONATION_EMBED || '').toLowerCase() === 'true';
             const donationChecks = [];
             if (requireDonation && donationEmbeds.length === 0) {
@@ -680,7 +680,7 @@ jobs:
               echo "::error::.github/smoke.config.json exists but is not valid JSON"
               exit 1
             fi
-            SCOPE=$(echo "$SCOPE" | tr '[:upper:]' '[:lower:]')
+            SCOPE=$(echo "$SCOPE" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
             case "$SCOPE" in
               '' | charity | ffc-interim | none) ;;
               *)


### PR DESCRIPTION
## Description

The smoke engine's donation posture (`charity` / `ffc-interim` / `none`) could previously only be declared via the `SMOKE_DONATION_SCOPE` Actions repository variable — invisible in the repo and not PR-reviewable. This adds a committed alternative: sites can declare their posture in `.github/smoke.config.json`:

```json
{ "donationScope": "none" }
```

Precedence: an explicitly-set Actions variable still overrides the committed file (ops override / backward compatible with sites already using the variable); when the variable is unset, the file applies; when neither exists, behavior is unchanged (undeclared).

First user: for-profit FFC-EX sites (e.g. FFC-EX-bulldogztowing.com, a towing company) that intentionally take no donations and were hard-failing the "No donation capability detected" compliance check.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update
- [x] CI/CD or tooling change

## Related Issue(s)

Refs the recurring Post-Deploy Smoke Test donation-compliance failures on for-profit FFC-EX sites.

## Changes Made

- `.github/workflows/post-deploy-smoke.yml` (canonical fleet smoke engine):
  - The Playwright compliance script reads `.github/smoke.config.json` and falls back to its `donationScope` when `SMOKE_DONATION_SCOPE` is unset
  - The "Maintain standing donation posture issues" step applies the same fallback via `jq`
  - The no-donation-capability error message now points to the committed file as the preferred declaration
  - Comment block documents the committed-file option

## Screenshots (if applicable)

N/A — CI/workflow change only.

## Testing Performed

### Manual Testing

- [x] Verified all interactive elements work correctly (N/A — no UI change)
- [x] Checked console for errors (N/A)

### Automated Testing

- [x] YAML validated (`yaml.safe_load` passes)
- [x] Embedded `visual.js` extracted and syntax-checked (`node --check` passes)
- [x] Prettier check passes on the workflow file

### Accessibility

- [x] N/A — no rendered-page change

## Documentation

- [x] Code is self-documenting or includes comments where needed
- [ ] README.md updated (if needed)
- [ ] Other documentation updated (if needed)

## Breaking Changes

None / N/A — with no committed file and no variable set, behavior is byte-for-byte the same as before.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix/feature works (validated via YAML/JS syntax checks; exercised by the first fleet consumer)
- [x] New and existing tests pass locally
- [x] I have updated the documentation accordingly
- [x] My commits follow the conventional commit format
- [x] I have rebased my branch on the latest main

## Additional Notes

This repo is the canonical source for the fleet smoke engine (workflow 738 in FFC-Cloudflare-Automation byte-compares every FFC-EX repo against it). FFC-EX-bulldogztowing.com will carry the identical updated engine plus a `smoke.config.json` declaring `"donationScope": "none"`; other fleet repos will show in the weekly drift audit until synced with this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xjjf3URfCNXNx5w4qj7yMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjjf3URfCNXNx5w4qj7yMk)_