### PR TITLE
fix(ci): include hidden files in Pages artifact so security.txt deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,11 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
+          # Keep dot-entries (.well-known/, .nojekyll) in the Pages artifact.
+          # upload-pages-artifact@v5 defaults include-hidden-files to false,
+          # which drops public/.well-known/security.txt and 404s the canonical
+          # RFC 9116 path. See FFC-Cloudflare-Automation#788.
+          include-hidden-files: true
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
## Description

`actions/upload-pages-artifact@v5` defaults `include-hidden-files` to `false`, which adds `--exclude=.[^/]*` to the tar it builds — silently dropping every dot-entry in `out/` (`.well-known/`, `.nojekyll`) from the Pages artifact. The file is present in the build output but never reaches the deployed site, so the canonical RFC 9116 path `/.well-known/security.txt` returns **404** on this template and every fork built from it (the `/security.txt` alternate still works). This one-line fix sets `include-hidden-files: true` on the upload step in `.github/workflows/deploy.yml`.

This is a clean, single-purpose replacement for the earlier draft #417, which stacked the same one-liner on top of 19 unmerged smoke-engine commits and so could not land as a security fix. This branch carries only the deploy.yml change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD or tooling change

## Related Issue(s)

Relates to FreeForCharity/FFC-Cloudflare-Automation#788

## Changes Made

- `.github/workflows/deploy.yml`: added `include-hidden-files: true` (with an explanatory comment) to the `actions/upload-pages-artifact@v5` step.

## Testing Performed

### Automated Testing

- [x] `npx prettier@3.8.1 --check .github/workflows/deploy.yml` — passes
- [x] YAML parses cleanly (`yaml.safe_load`)
- [x] Repo pre-commit hook (`prettier --check` + `eslint` + `check:drift`) — all pass

Full deploy verification is post-merge: after this lands on `main` and redeploys, confirm `curl -sS -o /dev/null -w '%{http_code}' https://<pages-url>/.well-known/security.txt` returns `200`. Reference fix proven live on FFC-EX-canary#16.

## Breaking Changes

None / N/A

## Additional Notes

Scope is deliberately just the Single Page template's deploy workflow. The Footer template already has a clean equivalent fix in an open draft (Footer_Only_Template#108); the FFC-EX fleet sweep and the optional smoke-engine `/.well-known/security.txt` 200 assertion tracked in the parent issue are left for the Conductor to route.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8gVkoT4Zb2evgL1TwDsZW)_