### PR TITLE
fix(ci): stop discarding next.config.ts on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,10 +42,25 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v6
-        with:
-          # Automatically inject basePath in your Next.js configuration file and disable
-          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
-          static_site_generator: next
+        # `static_site_generator: next` is deliberately NOT set. It only understands
+        # next.config.js/.mjs; this repo uses next.config.ts, so the action logged
+        # "Using default blank configuration" and WROTE ITS OWN next.config.js
+        # containing only {output, basePath, images.unoptimized}. Next prefers .js
+        # over .ts, so every deploy built with this repo's real config discarded:
+        # images.remotePatterns and the bundle-analyzer wrapper are simply gone from
+        # the config Next actually reads.
+        #
+        # Measured, not inferred: two consecutive deploys of Footer_Only_Template
+        # differing ONLY by this input flipped /privacy-policy/ from 404 to 200 and
+        # /privacy-policy.html from 200 to 404 — the shape its trailingSlash setting
+        # specifies.
+        #
+        # The basePath the action injects is NOT wrong — it derives from the Pages API
+        # and so honours a custom domain (this repo serves ffcworkingsite1.org with
+        # unprefixed assets while the input was still set). It agrees with the
+        # CNAME-aware value the step below computes. Removing the input is safe
+        # precisely because that step already produces the same answer.
+        # See FFC-Cloudflare-Automation#880.
 
       - name: Restore Next.js cache
         uses: actions/cache@v5


### PR DESCRIPTION
## What this fixes

`actions/configure-pages` with `static_site_generator: next` only understands
`next.config.js`/`.mjs`. This repo uses **`next.config.ts`**, so the action logs
*"Using default blank configuration"* and **writes its own `next.config.js`** containing only
`{output, basePath, images.unoptimized}`. Next prefers `.js` over `.ts` — so **every deploy has
built with this repo's real config discarded.**

## Evidence

Measured, not inferred. Two consecutive deploys of `FFC-IN-Footer_Only_Template`, same repo, same
source, **differing only by this input**:

| URL | With the input | Without it |
| --- | --- | --- |
| `…/privacy-policy/` | **404** | **200** |
| `…/privacy-policy.html` | **200** | **404** |

The shape inverted to exactly what `trailingSlash: true` in `next.config.ts` specifies.

## Why change SPT, which looks fine

There is no visible symptom here today — SPT does not set `trailingSlash`, so the URL shape is
correct by coincidence rather than by config. What it is silently losing is `images.remotePatterns`
and the `@next/bundle-analyzer` wrapper.

The reason to fix it anyway: **SPT is the template every provisioned site is copied from.** The next
setting anyone adds to its `next.config.ts` would silently not apply, and would be inherited as
not-applying by every child repo.

## Why this is safe

The basePath the action injects is **not** wrong — it derives from the Pages API, so it honours the
custom domain. This repo serves `ffcworkingsite1.org` with unprefixed assets *while the input was
still set*. The `Determine base path` step below computes the same value from `public/CNAME`. They
agree, so removing the input changes no URL.

(An earlier version of #880 claimed the action hardcoded `/<repo>` and blamed it for #748. That was
wrong and is corrected on the issue — #748 remains unexplained.)

## Verification after merge

Once deployed, `ffcworkingsite1.org` should be unchanged: assets unprefixed and resolving, pages
still at `.html` paths (SPT sets no `trailingSlash`, so its shape should **not** move). A change in
URL shape here would mean SPT's config differs from what I read, and should block the fleet rollout.

Refs FFC-Cloudflare-Automation#880
