### PR TITLE
fix: resolve the smoke engine's donation scope once, not twice

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -30,6 +30,73 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Resolve donation scope (one contract, both engine paths consume it)
+        # The donation posture is declared in two places (the
+        # SMOKE_DONATION_SCOPE repo variable and the committed
+        # .github/smoke.config.json) and consumed in two places (the
+        # Playwright compliance script and the standing-issue shell step).
+        # It is resolved HERE, once. Neither consumer reads the config file
+        # or the raw variable, because two implementations of one contract
+        # drift: they disagreed on when the file is validated, on whether a
+        # `null` config is empty or invalid, and on whether a
+        # variable-sourced value is trimmed. Refs FFC-Cloudflare-Automation#893.
+        id: scope
+        env:
+          SMOKE_DONATION_SCOPE: ${{ vars.SMOKE_DONATION_SCOPE }}
+        run: |
+          set -euo pipefail
+          cat > /tmp/resolve-donation-scope.js <<'RESOLVE_JS'
+          const fs = require('fs');
+          const VALID = ['charity', 'ffc-interim', 'none'];
+          const CONFIG_PATH = '.github/smoke.config.json';
+          const norm = (v) => String(v ?? '').trim().toLowerCase();
+
+          // The committed file is validated whenever it exists — including
+          // when the variable overrides it. A config that cannot be honoured
+          // is a defect in the repo whether or not today's run reads it.
+          let fileScope = '';
+          if (fs.existsSync(CONFIG_PATH)) {
+            let parsed;
+            try {
+              parsed = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+            } catch (e) {
+              console.error(`::error::${CONFIG_PATH} exists but is not valid JSON: ${e instanceof Error ? e.message : String(e)}`);
+              process.exit(1);
+            }
+            // Wrong TYPE is not bad syntax: null, [], "str" and 42 all parse.
+            // Reporting those as a syntax error sends the maintainer looking
+            // for a missing brace in a file that has none.
+            if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+              const got = parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed;
+              console.error(`::error::${CONFIG_PATH} must contain a JSON object (got ${got})`);
+              process.exit(1);
+            }
+            fileScope = norm(parsed.donationScope);
+            if (fileScope && !VALID.includes(fileScope)) {
+              console.error(`::error::${CONFIG_PATH} donationScope "${parsed.donationScope}" is not one of ${VALID.join('|')}`);
+              process.exit(1);
+            }
+          }
+
+          // An unrecognised repo variable is a typo, not a declaration: warn
+          // and fall through to the committed file rather than letting it
+          // silently mask a valid one.
+          const rawVar = process.env.SMOKE_DONATION_SCOPE;
+          const varScope = norm(rawVar);
+          if (varScope && !VALID.includes(varScope)) {
+            console.log(`::warning::SMOKE_DONATION_SCOPE "${rawVar}" is not one of ${VALID.join('|')} — ignoring it and falling back to ${CONFIG_PATH}`);
+          }
+          const effectiveVar = VALID.includes(varScope) ? varScope : '';
+
+          const scope = effectiveVar || fileScope;
+          const source = effectiveVar ? 'variable' : fileScope ? 'file' : 'undeclared';
+          console.log(`Donation scope: ${scope || '(undeclared)'} (source: ${source})`);
+          if (process.env.GITHUB_OUTPUT) {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `scope=${scope}\nsource=${source}\n`);
+          }
+          RESOLVE_JS
+          node /tmp/resolve-donation-scope.js
+
       - name: Determine smoke target from Pages config (ground truth)
         id: url
         env:
@@ -263,7 +330,9 @@ jobs:
           # {"donationScope": "none"} — repo-visible and PR-reviewable (e.g.
           # for-profit FFC-EX sites like towing companies). The variable, when
           # set, still overrides the committed file.
-          SMOKE_DONATION_SCOPE: ${{ vars.SMOKE_DONATION_SCOPE }}
+          # Already resolved, validated and normalized by the `scope` step —
+          # this script must not re-read the file or the raw variable.
+          SMOKE_DONATION_SCOPE: ${{ steps.scope.outputs.scope }}
           # Legacy (v3.2): require at least one Zeffy iframe embed specifically.
           SMOKE_REQUIRE_DONATION_EMBED: ${{ vars.SMOKE_REQUIRE_DONATION_EMBED }}
           # 'true' on template repos: their sites ARE the template default.
@@ -285,29 +354,6 @@ jobs:
             const requiredLinks = (process.env.SMOKE_REQUIRED_FOOTER_LINKS || '/privacy-policy,/terms-of-service|/tos')
               .split(',').map(s => s.trim()).filter(Boolean);
             const requireCookieConsent = String(process.env.SMOKE_REQUIRE_COOKIE_CONSENT || 'true').toLowerCase() !== 'false';
-            // Committed site declarations (.github/smoke.config.json) — the
-            // repo-visible alternative to Actions variables. An explicitly-set
-            // variable still wins over the file. A file that exists but does
-            // not parse is a hard error, not a silent fallback.
-            let fileConfig = {};
-            const smokeConfigPath = process.env.GITHUB_WORKSPACE + '/.github/smoke.config.json';
-            if (require('fs').existsSync(smokeConfigPath)) {
-              try {
-                fileConfig = JSON.parse(require('fs').readFileSync(smokeConfigPath, 'utf8'));
-              } catch (e) {
-                console.error(`::error::.github/smoke.config.json exists but is not valid JSON: ${e instanceof Error ? e.message : String(e)}`);
-                process.exit(1);
-              }
-              if (fileConfig === null || typeof fileConfig !== 'object' || Array.isArray(fileConfig)) {
-                console.error('::error::.github/smoke.config.json must contain a JSON object');
-                process.exit(1);
-              }
-              const fileScope = String(fileConfig.donationScope || '').trim().toLowerCase();
-              if (fileScope && !['charity', 'ffc-interim', 'none'].includes(fileScope)) {
-                console.error(`::error::.github/smoke.config.json donationScope "${fileConfig.donationScope}" is not one of charity|ffc-interim|none`);
-                process.exit(1);
-              }
-            }
 
             const browser = await chromium.launch();
             const ctx = await browser.newContext({
@@ -475,7 +521,7 @@ jobs:
 
             // Donation assertions — first-class: a charity site must never
             // silently lose its donation capability.
-            const donationScope = String(process.env.SMOKE_DONATION_SCOPE || fileConfig.donationScope || '').trim().toLowerCase();
+            const donationScope = String(process.env.SMOKE_DONATION_SCOPE || '');
             const requireDonation = String(process.env.SMOKE_REQUIRE_DONATION_EMBED || '').toLowerCase() === 'true';
             const donationChecks = [];
             if (requireDonation && donationEmbeds.length === 0) {
@@ -667,28 +713,12 @@ jobs:
         if: always() && !cancelled() && steps.url.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          SCOPE: ${{ vars.SMOKE_DONATION_SCOPE }}
+          # Already resolved, validated and normalized by the `scope` step —
+          # this step must not re-read the file or the raw variable.
+          SCOPE: ${{ steps.scope.outputs.scope }}
         run: |
           set -euo pipefail
           REPO="${GITHUB_REPOSITORY}"
-
-          # Committed declaration fallback: .github/smoke.config.json's
-          # donationScope applies when the SMOKE_DONATION_SCOPE variable is
-          # unset. A file that exists but does not parse is a hard error.
-          if [ -z "${SCOPE:-}" ] && [ -f .github/smoke.config.json ]; then
-            if ! SCOPE=$(jq -r '.donationScope // ""' .github/smoke.config.json); then
-              echo "::error::.github/smoke.config.json exists but is not valid JSON"
-              exit 1
-            fi
-            SCOPE=$(echo "$SCOPE" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
-            case "$SCOPE" in
-              '' | charity | ffc-interim | none) ;;
-              *)
-                echo "::error::.github/smoke.config.json donationScope \"$SCOPE\" is not one of charity|ffc-interim|none"
-                exit 1
-                ;;
-            esac
-          fi
 
           # --- donation-migration (auto-detected, provider-based) ---
           nonpref="false"; providers=""
@@ -726,7 +756,7 @@ jobs:
 
           # --- donation-interim (scope-declared) ---
           existing=$(gh api "repos/${REPO}/issues?state=open&labels=donation-interim&per_page=1" --jq '.[0].number // empty' || echo "")
-          scope=$(echo "${SCOPE:-}" | tr '[:upper:]' '[:lower:]')
+          scope="${SCOPE:-}"
 
           if [ "$scope" = "ffc-interim" ]; then
             if [ -z "$existing" ]; then

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -61,6 +61,12 @@ jobs:
           const VALID = ['charity', 'ffc-interim', 'none'];
           const CONFIG_PATH = '.github/smoke.config.json';
           const norm = (v) => String(v ?? '').trim().toLowerCase();
+          // Workflow commands are newline-delimited and percent-escaped, so a
+          // value carrying %, CR or LF can close the annotation early and have
+          // the rest parsed as further commands — a committed donationScope
+          // could emit ::stop-commands:: and silence the run's annotations.
+          // Escape anything interpolated into a ::error::/::warning:: line.
+          const esc = (v) => String(v ?? '').replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
 
           // The committed file is validated whenever it exists — including
           // when the variable overrides it. A config that cannot be honoured
@@ -71,7 +77,7 @@ jobs:
             try {
               parsed = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
             } catch (e) {
-              console.error(`::error::${CONFIG_PATH} exists but is not valid JSON: ${e instanceof Error ? e.message : String(e)}`);
+              console.error(`::error::${CONFIG_PATH} exists but is not valid JSON: ${esc(e instanceof Error ? e.message : String(e))}`);
               process.exit(1);
             }
             // Wrong TYPE is not bad syntax: null, [], "str" and 42 all parse.
@@ -84,7 +90,7 @@ jobs:
             }
             fileScope = norm(parsed.donationScope);
             if (fileScope && !VALID.includes(fileScope)) {
-              console.error(`::error::${CONFIG_PATH} donationScope "${parsed.donationScope}" is not one of ${VALID.join('|')}`);
+              console.error(`::error::${CONFIG_PATH} donationScope "${esc(parsed.donationScope)}" is not one of ${VALID.join('|')}`);
               process.exit(1);
             }
           }
@@ -99,9 +105,9 @@ jobs:
             // in the file there is nothing to fall back TO, and a maintainer
             // told otherwise goes looking for a file that isn't there.
             const outcome = fileScope
-              ? `falling back to ${CONFIG_PATH} ("${fileScope}")`
+              ? `falling back to ${CONFIG_PATH} ("${esc(fileScope)}")`
               : `scope is undeclared (no usable donationScope in ${CONFIG_PATH})`;
-            console.log(`::warning::SMOKE_DONATION_SCOPE "${rawVar}" is not one of ${VALID.join('|')} — ignoring it; ${outcome}`);
+            console.log(`::warning::SMOKE_DONATION_SCOPE "${esc(rawVar)}" is not one of ${VALID.join('|')} — ignoring it; ${outcome}`);
           }
           const effectiveVar = VALID.includes(varScope) ? varScope : '';
 

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -95,7 +95,13 @@ jobs:
           const rawVar = process.env.SMOKE_DONATION_SCOPE;
           const varScope = norm(rawVar);
           if (varScope && !VALID.includes(varScope)) {
-            console.log(`::warning::SMOKE_DONATION_SCOPE "${rawVar}" is not one of ${VALID.join('|')} — ignoring it and falling back to ${CONFIG_PATH}`);
+            // Name the outcome, not the intention: with no usable declaration
+            // in the file there is nothing to fall back TO, and a maintainer
+            // told otherwise goes looking for a file that isn't there.
+            const outcome = fileScope
+              ? `falling back to ${CONFIG_PATH} ("${fileScope}")`
+              : `scope is undeclared (no usable donationScope in ${CONFIG_PATH})`;
+            console.log(`::warning::SMOKE_DONATION_SCOPE "${rawVar}" is not one of ${VALID.join('|')} — ignoring it; ${outcome}`);
           }
           const effectiveVar = VALID.includes(varScope) ? varScope : '';
 

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -30,6 +30,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        # Ahead of the scope resolver, not just ahead of Playwright. The
+        # resolver is a node script, so the toolchain it runs on is declared
+        # here rather than inherited from whatever the runner image happens
+        # to ship. Unconditional for the same reason: it must be in place
+        # before the first step that needs it, which now runs before the
+        # skip decision.
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Resolve donation scope (one contract, both engine paths consume it)
         # The donation posture is declared in two places (the
         # SMOKE_DONATION_SCOPE repo variable and the committed
@@ -282,12 +293,6 @@ jobs:
           done
           echo "Checked $checked routes; $fail failed"
           if [ "$fail" -gt 0 ]; then exit 1; fi
-
-      - name: Setup Node for visual check
-        if: steps.url.outputs.skip != 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
 
       - name: Install Playwright (chromium only)
         if: steps.url.outputs.skip != 'true'

--- a/__tests__/workflows/donation-scope.test.ts
+++ b/__tests__/workflows/donation-scope.test.ts
@@ -187,16 +187,29 @@ describe('donation scope resolution — an unrecognised repo variable', () => {
     const r = run(JSON.stringify({ donationScope: 'none' }), 'nonee')
     expect(r.code).toBe(0)
     expect(r.stdout).toContain('::warning::')
+    expect(r.stdout).toContain('falling back to .github/smoke.config.json ("none")')
     expect(r.scope).toBe('none')
     expect(r.source).toBe('file')
   })
 
+  // The warning must describe what actually happened. Promising a fallback
+  // to a file that does not exist sends a maintainer looking for it.
   it('warns and reports undeclared when there is no file to fall back to', () => {
     const r = run(null, 'nonee')
     expect(r.code).toBe(0)
     expect(r.stdout).toContain('::warning::')
+    expect(r.stdout).toContain('scope is undeclared')
+    expect(r.stdout).not.toContain('falling back to')
     expect(r.scope).toBe('')
     expect(r.source).toBe('undeclared')
+  })
+
+  it('says undeclared when the file exists but declares no scope', () => {
+    const r = run('{}', 'nonee')
+    expect(r.code).toBe(0)
+    expect(r.stdout).toContain('scope is undeclared')
+    expect(r.stdout).not.toContain('falling back to')
+    expect(r.scope).toBe('')
   })
 })
 

--- a/__tests__/workflows/donation-scope.test.ts
+++ b/__tests__/workflows/donation-scope.test.ts
@@ -233,6 +233,25 @@ describe('the contract has exactly one implementation', () => {
     }
   })
 
+  it('node is set up before the resolver runs, not inherited from the image', () => {
+    // The resolver is a node script that runs before the smoke even knows
+    // its target, so it must not depend on whatever node the runner image
+    // happens to ship. Ordering is the whole guarantee here, and ordering is
+    // exactly what a later edit reshuffles without noticing.
+    const names = [...workflow.matchAll(/\n      - name: (.*)/g)].map((m) => m[1])
+    const setupNode = names.findIndex((n) => n === 'Setup Node')
+    const resolver = names.findIndex((n) => n.startsWith('Resolve donation scope'))
+    expect(setupNode).toBeGreaterThan(-1)
+    expect(resolver).toBeGreaterThan(-1)
+    expect(setupNode).toBeLessThan(resolver)
+
+    // ...and it must be unconditional: every `if:` in this job keys off the
+    // skip decision, which is made in a step that now runs AFTER the resolver.
+    const step = stepBodies('- name: Setup Node\n')
+    expect(step).toContain('actions/setup-node')
+    expect(step).not.toContain('if:')
+  })
+
   it('the Playwright compliance step consumes the resolved output', () => {
     const step = stepBodies('- name: Visual check + screenshot + compliance assertions')
     expect(step).toContain('SMOKE_DONATION_SCOPE: ${{ steps.scope.outputs.scope }}')

--- a/__tests__/workflows/donation-scope.test.ts
+++ b/__tests__/workflows/donation-scope.test.ts
@@ -264,17 +264,40 @@ describe('the contract has exactly one implementation', () => {
     )
     expect(resolvers).toHaveLength(1)
 
+    // Two signals, both required, deliberately not on the same line. The
+    // implementation this guard replaced built its path on one line and
+    // called existsSync on the next:
+    //
+    //   const smokeConfigPath = process.env.GITHUB_WORKSPACE + '/.github/smoke.config.json'
+    //   if (require('fs').existsSync(smokeConfigPath)) {
+    //
+    // so a regex demanding the primitive and the path together would miss
+    // the exact regression this exists to catch. Requiring both anywhere in
+    // the SAME STEP keeps that catch while leaving a step that reads some
+    // unrelated file — and never mentions this config — alone.
     const readPrimitives = [
       /existsSync/,
       /readFileSync/,
       /\[ -f \.github\/smoke\.config\.json/,
       /jq -r '\.donationScope/,
     ]
+    const NEAR = 3
     const otherSteps = steps.filter((s) => !resolvers.includes(s))
     for (const step of otherSteps) {
-      const name = step.split('\n')[0]
+      const lines = step.split('\n')
+      const name = lines[0]
+      // The Playwright step legitimately names the config in a compliance
+      // message, so "mentions it anywhere" is not the signal either — it is
+      // a read PRIMITIVE sitting within a few lines of the path.
+      const mentions = lines.flatMap((l, i) => (l.includes('smoke.config.json') ? [i] : []))
+      if (mentions.length === 0) continue
       for (const primitive of readPrimitives) {
-        expect(`${name}: ${primitive.test(step)}`).toBe(`${name}: false`)
+        const near = lines.flatMap((l, i) =>
+          primitive.test(l) && mentions.some((m) => Math.abs(i - m) <= NEAR) ? [i + 1] : []
+        )
+        expect(`${name}: ${near.length ? `reads config at line ${near[0]}` : 'clean'}`).toBe(
+          `${name}: clean`
+        )
       }
     }
   })

--- a/__tests__/workflows/donation-scope.test.ts
+++ b/__tests__/workflows/donation-scope.test.ts
@@ -1,0 +1,256 @@
+/**
+ * The donation-scope contract of the post-deploy smoke engine.
+ *
+ * This file is propagated across the FFC fleet by byte-identity (see the
+ * fleet smoke-engine drift audit, FFC-Cloudflare-Automation#893), so every
+ * defect in it ships to ~60 repos at once. The contract used to be
+ * implemented TWICE inside the workflow — once in the Playwright compliance
+ * script and once in the standing-issue shell step — and the two
+ * implementations disagreed three ways: on when the committed config is
+ * validated, on whether a `null` config is "empty" or "invalid", and on
+ * whether a variable-sourced value is trimmed.
+ *
+ * The fix was to resolve it once, in the `scope` step. These tests drive the
+ * SHIPPED resolver text out of the workflow file and run it, so they fail if
+ * the behaviour changes — and the structural guards at the bottom fail if a
+ * second implementation is ever reintroduced.
+ */
+import { execFileSync } from 'child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const WORKFLOW_PATH = join(__dirname, '..', '..', '.github', 'workflows', 'post-deploy-smoke.yml')
+const workflow = readFileSync(WORKFLOW_PATH, 'utf8')
+
+/** Pull the resolver script out of its heredoc and undo the YAML indentation. */
+function extractResolver(): string {
+  const match = workflow.match(/<<'RESOLVE_JS'\n([\s\S]*?)\n[ \t]*RESOLVE_JS\n/)
+  if (!match) throw new Error('Could not find the RESOLVE_JS heredoc in post-deploy-smoke.yml')
+  const lines = match[1].split('\n')
+  const indent = Math.min(
+    ...lines.filter((l) => l.trim().length > 0).map((l) => l.match(/^ */)![0].length)
+  )
+  return lines.map((l) => l.slice(indent)).join('\n')
+}
+
+const RESOLVER = extractResolver()
+
+interface RunResult {
+  code: number
+  stdout: string
+  stderr: string
+  scope: string | null
+  source: string | null
+}
+
+/**
+ * Run the shipped resolver against a fixture repo.
+ *
+ * @param config  contents of .github/smoke.config.json, or null for "no file"
+ * @param scopeVar value of the SMOKE_DONATION_SCOPE repo variable ('' = unset)
+ */
+function run(config: string | null, scopeVar = ''): RunResult {
+  const dir = mkdtempSync(join(tmpdir(), 'smoke-scope-'))
+  mkdirSync(join(dir, '.github'), { recursive: true })
+  if (config !== null) writeFileSync(join(dir, '.github', 'smoke.config.json'), config)
+  const scriptPath = join(dir, 'resolve.js')
+  writeFileSync(scriptPath, RESOLVER)
+  const outputPath = join(dir, 'gh-output')
+  writeFileSync(outputPath, '')
+
+  let code = 0
+  let stdout = ''
+  let stderr = ''
+  try {
+    stdout = execFileSync('node', [scriptPath], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        SMOKE_DONATION_SCOPE: scopeVar,
+        GITHUB_OUTPUT: outputPath,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (e) {
+    const err = e as { status?: number; stdout?: string; stderr?: string }
+    code = err.status ?? 1
+    stdout = err.stdout ?? ''
+    stderr = err.stderr ?? ''
+  }
+
+  const written = existsSync(outputPath) ? readFileSync(outputPath, 'utf8') : ''
+  const read = (key: string) => {
+    const m = written.match(new RegExp(`^${key}=(.*)$`, 'm'))
+    return m ? m[1] : null
+  }
+  return { code, stdout, stderr, scope: read('scope'), source: read('source') }
+}
+
+describe('donation scope resolution — valid declarations', () => {
+  it('reports undeclared when neither the file nor the variable is set', () => {
+    const r = run(null)
+    expect(r.code).toBe(0)
+    expect(r.scope).toBe('')
+    expect(r.source).toBe('undeclared')
+  })
+
+  it('reports undeclared for an object with no donationScope key', () => {
+    const r = run('{}')
+    expect(r.code).toBe(0)
+    expect(r.scope).toBe('')
+    expect(r.source).toBe('undeclared')
+  })
+
+  it.each(['charity', 'ffc-interim', 'none'])('accepts %s from the committed file', (scope) => {
+    const r = run(JSON.stringify({ donationScope: scope }))
+    expect(r.code).toBe(0)
+    expect(r.scope).toBe(scope)
+    expect(r.source).toBe('file')
+  })
+
+  it('lets the repo variable override the committed file', () => {
+    const r = run(JSON.stringify({ donationScope: 'none' }), 'charity')
+    expect(r.code).toBe(0)
+    expect(r.scope).toBe('charity')
+    expect(r.source).toBe('variable')
+  })
+})
+
+describe('donation scope resolution — normalization is the same for both sources', () => {
+  // The shell path used to strip whitespace only inside the file branch, so
+  // a variable-sourced ' charity ' matched no case arm downstream.
+  it('trims and lowercases a value that came from the file', () => {
+    const r = run(JSON.stringify({ donationScope: '  Charity ' }))
+    expect(r.code).toBe(0)
+    expect(r.scope).toBe('charity')
+  })
+
+  it('trims and lowercases a value that came from the variable', () => {
+    const r = run(null, '  FFC-Interim ')
+    expect(r.code).toBe(0)
+    expect(r.scope).toBe('ffc-interim')
+    expect(r.source).toBe('variable')
+  })
+})
+
+describe('donation scope resolution — invalid input', () => {
+  it('rejects unparseable JSON as a syntax error', () => {
+    const r = run('{ not json')
+    expect(r.code).toBe(1)
+    expect(r.stderr).toContain('is not valid JSON')
+  })
+
+  // `null`, `[]`, `"str"` and `42` all PARSE. The old shell path called them
+  // "not valid JSON" (sending a maintainer after a syntax error that does not
+  // exist), and `null` in particular resolved silently to an empty scope.
+  it.each([
+    ['null', 'null'],
+    ['[]', 'array'],
+    ['"hello"', 'string'],
+    ['42', 'number'],
+    ['true', 'boolean'],
+  ])('rejects top-level %s as a type error, not a syntax error', (config, got) => {
+    const r = run(config)
+    expect(r.code).toBe(1)
+    expect(r.stderr).toContain('must contain a JSON object')
+    expect(r.stderr).toContain(`(got ${got})`)
+    expect(r.stderr).not.toContain('is not valid JSON')
+  })
+
+  it('rejects a donationScope outside the allowed set', () => {
+    const r = run(JSON.stringify({ donationScope: 'sometimes' }))
+    expect(r.code).toBe(1)
+    expect(r.stderr).toContain('is not one of charity|ffc-interim|none')
+  })
+
+  // The divergence that started this: the JS path validated the file even
+  // when the variable was set, the shell path never opened it. One workflow
+  // cannot hold both rules — validation now happens either way.
+  it('still validates a malformed file when the variable would override it', () => {
+    const r = run('{ not json', 'none')
+    expect(r.code).toBe(1)
+    expect(r.stderr).toContain('is not valid JSON')
+  })
+
+  it('still validates a bad file donationScope when the variable would override it', () => {
+    const r = run(JSON.stringify({ donationScope: 'sometimes' }), 'none')
+    expect(r.code).toBe(1)
+    expect(r.stderr).toContain('is not one of charity|ffc-interim|none')
+  })
+})
+
+describe('donation scope resolution — an unrecognised repo variable', () => {
+  // A typo'd variable must not silently mask a valid committed declaration.
+  it('warns and falls back to the committed file', () => {
+    const r = run(JSON.stringify({ donationScope: 'none' }), 'nonee')
+    expect(r.code).toBe(0)
+    expect(r.stdout).toContain('::warning::')
+    expect(r.scope).toBe('none')
+    expect(r.source).toBe('file')
+  })
+
+  it('warns and reports undeclared when there is no file to fall back to', () => {
+    const r = run(null, 'nonee')
+    expect(r.code).toBe(0)
+    expect(r.stdout).toContain('::warning::')
+    expect(r.scope).toBe('')
+    expect(r.source).toBe('undeclared')
+  })
+})
+
+describe('the contract has exactly one implementation', () => {
+  const stepBodies = (heading: string) => {
+    const start = workflow.indexOf(heading)
+    expect(start).toBeGreaterThan(-1)
+    const next = workflow.indexOf('\n      - name:', start + heading.length)
+    return workflow.slice(start, next === -1 ? workflow.length : next)
+  }
+
+  it('only the resolver step opens .github/smoke.config.json', () => {
+    // Steps may NAME the file in an error message or an issue body — that is
+    // how a maintainer learns where to declare the scope. What no step but
+    // the resolver may do is READ it.
+    const steps = workflow.split(/\n      - name: /).slice(1)
+    const resolvers = steps.filter((s) =>
+      s.includes("const CONFIG_PATH = '.github/smoke.config.json'")
+    )
+    expect(resolvers).toHaveLength(1)
+
+    const readPrimitives = [
+      /existsSync/,
+      /readFileSync/,
+      /\[ -f \.github\/smoke\.config\.json/,
+      /jq -r '\.donationScope/,
+    ]
+    const otherSteps = steps.filter((s) => !resolvers.includes(s))
+    for (const step of otherSteps) {
+      const name = step.split('\n')[0]
+      for (const primitive of readPrimitives) {
+        expect(`${name}: ${primitive.test(step)}`).toBe(`${name}: false`)
+      }
+    }
+  })
+
+  it('the Playwright compliance step consumes the resolved output', () => {
+    const step = stepBodies('- name: Visual check + screenshot + compliance assertions')
+    expect(step).toContain('SMOKE_DONATION_SCOPE: ${{ steps.scope.outputs.scope }}')
+    expect(step).not.toContain('vars.SMOKE_DONATION_SCOPE')
+    expect(step).not.toContain('fileConfig')
+  })
+
+  it('the standing-issue step consumes the resolved output', () => {
+    const step = stepBodies('- name: Maintain standing donation posture issues')
+    expect(step).toContain('SCOPE: ${{ steps.scope.outputs.scope }}')
+    expect(step).not.toContain('vars.SMOKE_DONATION_SCOPE')
+    expect(step).not.toContain('jq -r')
+  })
+
+  it('no consumer re-normalizes the resolved value', () => {
+    const step = stepBodies('- name: Maintain standing donation posture issues')
+    // `tr '[:upper:]' '[:lower:]'` on an already-normalized value is how the
+    // second implementation grew back last time.
+    expect(step).not.toMatch(/SCOPE.*tr '\[:upper:\]'/)
+  })
+})

--- a/__tests__/workflows/donation-scope.test.ts
+++ b/__tests__/workflows/donation-scope.test.ts
@@ -213,6 +213,39 @@ describe('donation scope resolution — an unrecognised repo variable', () => {
   })
 })
 
+describe('donation scope resolution — values reaching workflow commands are escaped', () => {
+  // ::error::/::warning:: lines are newline-delimited and percent-escaped.
+  // An unescaped value can close the annotation and have the remainder
+  // parsed as further commands — including ::stop-commands::, which would
+  // silence every annotation the rest of the run emits.
+  it('escapes CR, LF and % in a rejected file donationScope', () => {
+    const r = run(JSON.stringify({ donationScope: 'bad\nvalue\rwith%percent' }))
+    expect(r.code).toBe(1)
+    const line = r.stderr.split('\n').find((l) => l.startsWith('::error::'))!
+    expect(line).toContain('%0A')
+    expect(line).toContain('%0D')
+    expect(line).toContain('%25')
+    // The whole annotation is one line: nothing escaped from it.
+    expect(r.stderr.trim().split('\n')).toHaveLength(1)
+  })
+
+  it('escapes a forged command smuggled through the file', () => {
+    const r = run(JSON.stringify({ donationScope: 'x\n::stop-commands::abc' }))
+    expect(r.code).toBe(1)
+    expect(r.stderr).not.toMatch(/^::stop-commands::/m)
+  })
+
+  it('escapes CR, LF and % in an unrecognised repo variable', () => {
+    const r = run(null, 'bad\nvalue\rwith%percent')
+    expect(r.code).toBe(0)
+    const line = r.stdout.split('\n').find((l) => l.startsWith('::warning::'))!
+    expect(line).toContain('%0A')
+    expect(line).toContain('%0D')
+    expect(line).toContain('%25')
+    expect(r.stdout).not.toMatch(/^::stop-commands::/m)
+  })
+})
+
 describe('the contract has exactly one implementation', () => {
   const stepBodies = (heading: string) => {
     const start = workflow.indexOf(heading)


### PR DESCRIPTION
## Description

The post-deploy smoke engine lets a site declare its donation posture two ways (the `SMOKE_DONATION_SCOPE` repo variable and a committed `.github/smoke.config.json`) and consumes it in two places (the Playwright compliance script and the standing-issue shell step). Each consumer **implemented the resolution contract itself**, and the two implementations disagreed.

This is the file the fleet propagates **by byte-identity** (FreeForCharity/FFC-Cloudflare-Automation#893 — 61 repos currently divergent), so a defect here ships everywhere at once, uniformly. Two independent reviews found three divergences in a single feature; rather than patch three symptoms in two implementations, the scope is now resolved **once**, in a new `scope` step that both consumers read.

### The three divergences

| # | JS path | Shell path | Silent? |
| --- | --- | --- | --- |
| 1 | validates the committed config whenever it exists | only opens it when the variable is unset | No — a set variable + malformed file hard-failed one path and was never seen by the other |
| 2 | rejects a non-object top level | `null` → empty scope; `[]` / `"str"` / `42` → **"is not valid JSON"** on a file that *is* valid JSON | **Yes**, for `null` |
| 3 | trims both sources | strips whitespace only in the file branch | **Yes** — variable-sourced `" charity "` reached Playwright trimmed and the issue step untrimmed, matching no case arm |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test addition/update
- [x] CI/CD or tooling change

## Related Issue(s)

Refs FreeForCharity/FFC-Cloudflare-Automation#893 · surfaced by review on FreeForCharity/FFC-IN-Footer_Only_Template#123 and FreeForCharity/FFC-EX-canary#22

## Changes Made

- **New `scope` step** (runs right after checkout) resolves and validates the donation scope once, emitting `scope` and `source` outputs. It stays **inline in this workflow file** — a helper script would not survive byte-identity propagation.
- **Playwright step** consumes `steps.scope.outputs.scope`; its config-reading/validating block is deleted.
- **Standing-issue step** consumes `steps.scope.outputs.scope`; its `jq` fallback block and its re-lowercasing are deleted.
- **`__tests__/workflows/donation-scope.test.ts`** — 23 tests that extract the *shipped* resolver text from the YAML heredoc and execute it against fixture repos, plus structural guards asserting no other step opens the config file and no consumer re-normalizes the value.

### Behaviour changes (intentional)

1. The committed config is validated **even when the variable overrides it** — a config that cannot be honoured is a repo defect either way.
2. A wrong top-level type reports a **type** error (`must contain a JSON object (got null)`) instead of a misleading syntax error.
3. An **unrecognised variable warns and falls back to the file** rather than silently masking a valid declaration. Previously a typo'd variable produced an unrecognized scope with no signal; the resulting enforcement is the same, now with a `::warning::`.

Precedence is unchanged: a valid variable still wins over the committed file.

## Testing Performed

### Automated Testing

- [x] `npm run lint` — clean
- [x] `npm test` — **42 suites / 204 tests pass** (23 new)
- [x] `npx prettier --check` — clean on both changed files
- [x] `npm run check:drift` — no drift
- [x] `actionlint` (v1.7.7) — clean on `post-deploy-smoke.yml`
- [ ] `npm run build` / `npm run test:e2e` — **not run**: no application code, config or route changed; the diff is one workflow file plus one test. CI runs both.

### Mutation testing

A guard that cannot fail is not a guard. Reverting each fixed behaviour to its pre-fix form fires exactly the intended tests, and restoring clears them:

```
M1  drop the top-level type check          → 5 FAIL  (null, [], "hello", 42, true)
M2  skip the file read when the var is set → 3 FAIL  (both "still validates …" + the fallback warning)
M3  stop trimming in norm()                → 2 FAIL  (file-sourced and variable-sourced trim)
```

### Manual Testing

Not applicable — no UI surface. The engine itself only runs post-deploy on `main`; the resolver is exercised directly by the new tests.

## Breaking Changes

None for sites with a valid declaration. A repo whose committed `.github/smoke.config.json` is malformed **and** which sets the variable will now fail its smoke run where it previously passed — that is the point of change 1, and it is a real defect being surfaced.

## Additional Notes

**Sequencing.** The two open sync PRs (FreeForCharity/FFC-IN-Footer_Only_Template#123, FreeForCharity/FFC-EX-canary#22) are verbatim copies of canonical *as it is today* and are deliberately held. Once this merges, canonical's hash changes and both need a one-command re-sync before the fleet-wide propagation runs — otherwise the pre-fix contract reaches 61 repos and every one of them re-diverges on the next canonical change.

The 61 divergent repos do **not** carry this bug: they predate the `smoke.config.json` feature entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMPiuwAdbpTt1gtEmrUvZd)_