### PR TITLE
fix(security): stop the inert public/_headers check from masking the only CSP that is served

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ If you encounter any of the following, STOP and ask before editing:
 - A request to embed a third-party widget — the new origin must be added to
   BOTH public/\_headers AND the CSP meta tag in src/app/layout.tsx. The
   drift check enforces these two stay in sync; CI will fail on mismatch.
+  Only the meta tag is actually served (public/\_headers is inert on FFC's
+  GitHub Pages + Cloudflare proxy stack), so the meta tag is the one that
+  decides whether the widget loads.
 ```
 
 </details>

--- a/TEMPLATE_CUSTOMIZATION.md
+++ b/TEMPLATE_CUSTOMIZATION.md
@@ -107,22 +107,38 @@ If you have a real need to change one of these, open an issue first.
 
 ## Security surface
 
-| Concern                  | Where it lives                                                       |
-| ------------------------ | -------------------------------------------------------------------- |
-| CSP (Cloudflare/Netlify) | `public/_headers`                                                    |
-| CSP (GitHub Pages)       | `<meta httpEquiv="Content-Security-Policy">` in `src/app/layout.tsx` |
-| security.txt             | `public/.well-known/security.txt`                                    |
-| Vuln disclosure page     | `src/app/vulnerability-disclosure-policy/page.tsx`                   |
-| Branch protection        | `SECURITY.md` (configure in GitHub repo settings)                    |
-| Dep scanning             | `.github/dependabot.yml`, `.github/workflows/security-audit.yml`     |
-| Static analysis (CodeQL) | GitHub code scanning **default setup** (no `codeql.yml` workflow)    |
-| Supply-chain score       | `.github/workflows/scorecard.yml`                                    |
-| Secret patterns          | `scripts/check-drift.mjs` (locally) + GitHub secret scanning         |
+| Concern                     | Where it lives                                                       |
+| --------------------------- | -------------------------------------------------------------------- |
+| CSP (**the one served**)    | `<meta httpEquiv="Content-Security-Policy">` in `src/app/layout.tsx` |
+| CSP (inert, forward-compat) | `public/_headers` — see the warning below                            |
+| security.txt                | `public/.well-known/security.txt`                                    |
+| Vuln disclosure page        | `src/app/vulnerability-disclosure-policy/page.tsx`                   |
+| Branch protection           | `SECURITY.md` (configure in GitHub repo settings)                    |
+| Dep scanning                | `.github/dependabot.yml`, `.github/workflows/security-audit.yml`     |
+| Static analysis (CodeQL)    | GitHub code scanning **default setup** (no `codeql.yml` workflow)    |
+| Supply-chain score          | `.github/workflows/scorecard.yml`                                    |
+| Secret patterns             | `scripts/check-drift.mjs` (locally) + GitHub secret scanning         |
+
+> **`public/_headers` is inert on FFC deploys.** It is a Cloudflare Pages /
+> Netlify build feature. FFC sites are a GitHub Pages origin behind the
+> Cloudflare _proxy_, and neither reads the file — measured on the wire in
+> [FFC-Cloudflare-Automation#884](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/884).
+> Do not count it as security coverage, and do not treat adding it to a site as
+> closing a header gap.
+
+Only the CSP `<meta>` tag is actually served. The other five headers in
+`public/_headers` — HSTS, `X-Frame-Options`, `X-Content-Type-Options`,
+`Referrer-Policy`, `Permissions-Policy` — **cannot be set from a static export
+at all**; `<meta http-equiv>` is ignored for them. Serving those needs a
+response-header rule on the Cloudflare zone, tracked fleet-wide in
+[FFC-Cloudflare-Automation#894](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/894).
 
 When you add a new third-party origin (analytics, embed, payment), update
-**both** `public/_headers` and the CSP `<meta>` tag in `src/app/layout.tsx` —
-otherwise the resource will load on Cloudflare-hosted sites but fail on
-GitHub Pages, or vice versa.
+**both** `public/_headers` and the CSP `<meta>` tag in `src/app/layout.tsx`.
+Only the `<meta>` tag changes what the live site allows today; the `_headers`
+copy is kept in lockstep so a future move to Cloudflare Pages inherits a
+correct policy rather than a stale one. `npm run check:drift` errors if the two
+disagree.
 
 ## Verifying nothing drifted
 

--- a/__tests__/scripts/check-drift-csp.test.ts
+++ b/__tests__/scripts/check-drift-csp.test.ts
@@ -1,0 +1,168 @@
+import { spawnSync } from 'node:child_process'
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Contract tests for checkCspSync in scripts/check-drift.mjs.
+ *
+ * The property under test is which finding has the standing to fail a run.
+ * `public/_headers` is a Cloudflare Pages / Netlify build feature and is inert
+ * on the stack FFC deploys (GitHub Pages origin behind the Cloudflare proxy —
+ * measured in FFC-Cloudflare-Automation#884), so a finding about it must be a
+ * warning AND must never suppress the finding about the layout.tsx CSP meta
+ * tag, which is the only security header an FFC site actually serves.
+ *
+ * Before this was fixed, two of the three `_headers` states returned early and
+ * a site with no CSP anywhere passed the check reporting only the inert file.
+ */
+const root = join(__dirname, '..', '..')
+
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self'",
+  "img-src 'self'",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "frame-src 'self'",
+  "media-src 'self'",
+  "form-action 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+].join('; ')
+
+type HeadersState = 'absent' | 'no-csp' | 'csp'
+
+function layoutSource(withMeta: boolean): string {
+  const meta = withMeta ? `<meta httpEquiv="Content-Security-Policy" content="${CSP}" />` : ''
+  return `export default function RootLayout() {
+  return (
+    <html><head>${meta}</head><body /></html>
+  )
+}
+`
+}
+
+/** Builds a throwaway repo carrying only what checkCspSync reads. */
+function run(headers: HeadersState, layoutMeta: boolean): { code: number; output: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'ffc-drift-csp-'))
+  try {
+    mkdirSync(join(dir, 'scripts'), { recursive: true })
+    mkdirSync(join(dir, 'src/app'), { recursive: true })
+    mkdirSync(join(dir, 'src/lib'), { recursive: true })
+    mkdirSync(join(dir, 'public/.well-known'), { recursive: true })
+    cpSync(join(root, 'scripts/check-drift.mjs'), join(dir, 'scripts/check-drift.mjs'))
+    // The other checks read these; copy the real ones so their findings stay
+    // out of the way and only the CSP assertions vary between cases.
+    cpSync(join(root, 'src/lib/site.config.ts'), join(dir, 'src/lib/site.config.ts'))
+    cpSync(join(root, 'public/security.txt'), join(dir, 'public/security.txt'))
+    cpSync(
+      join(root, 'public/.well-known/security.txt'),
+      join(dir, 'public/.well-known/security.txt')
+    )
+
+    writeFileSync(join(dir, 'src/app/layout.tsx'), layoutSource(layoutMeta))
+    if (headers === 'no-csp') {
+      writeFileSync(join(dir, 'public/_headers'), '/*\n  X-Frame-Options: SAMEORIGIN\n')
+    } else if (headers === 'csp') {
+      writeFileSync(join(dir, 'public/_headers'), `/*\n  Content-Security-Policy: ${CSP}\n`)
+    }
+
+    return runScript(join(dir, 'scripts/check-drift.mjs'))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+/**
+ * Both streams, always. The script prints errors AND warnings via
+ * console.error/console.warn (stderr) and only the summary line to stdout, so
+ * reading stdout alone makes every warning assertion vacuously fail — and, more
+ * dangerously, would make a "does not contain" assertion pass for the wrong
+ * reason.
+ */
+function runScript(scriptPath: string): { code: number; output: string } {
+  const res = spawnSync(process.execPath, [scriptPath], { encoding: 'utf8' })
+  return { code: res.status ?? 1, output: `${res.stdout ?? ''}${res.stderr ?? ''}` }
+}
+
+const HEADERS_STATES: HeadersState[] = ['absent', 'no-csp', 'csp']
+
+describe('check-drift CSP: the inert file never masks the live control', () => {
+  // The regression this file exists for. Run as a matrix rather than a single
+  // case because the masking bug lived in the early returns, so it only showed
+  // up in the _headers states that returned before reaching the layout check.
+  it.each(HEADERS_STATES)(
+    'fails when the layout CSP meta tag is missing, with _headers %s',
+    (headers) => {
+      const { code, output } = run(headers, false)
+      expect(output).toContain(
+        'src/app/layout.tsx has no <meta http-equiv="Content-Security-Policy">'
+      )
+      expect(code).toBe(1)
+    }
+  )
+
+  it.each(HEADERS_STATES)('passes on a served CSP, with _headers %s', (headers) => {
+    const { code } = run(headers, true)
+    expect(code).toBe(0)
+  })
+})
+
+describe('check-drift CSP: _headers findings are warnings, not coverage', () => {
+  it('warns rather than errors when public/_headers is missing', () => {
+    const { code, output } = run('absent', true)
+    expect(output).toContain('public/_headers is missing')
+    // The claim under test is the severity: the file is inert, so its absence
+    // changes nothing that is served and must not fail the run.
+    expect(output).toContain('inert on FFC deploys')
+    expect(code).toBe(0)
+  })
+
+  it('warns rather than errors when public/_headers carries no CSP', () => {
+    const { code, output } = run('no-csp', true)
+    expect(output).toContain('public/_headers has no Content-Security-Policy directive')
+    expect(code).toBe(0)
+  })
+
+  it('does not claim security headers will stop being served', () => {
+    const { output } = run('absent', true)
+    // The pre-fix text read "CSP and other security headers will not be served",
+    // which was false on this stack in both directions: restoring the file
+    // serves nothing, and the CSP that IS served comes from layout.tsx.
+    expect(output).not.toContain('security headers will not be served')
+  })
+})
+
+describe('check-drift CSP: the sync diff still holds', () => {
+  it('errors when a third-party origin exists in only one of the two copies', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ffc-drift-csp-sync-'))
+    try {
+      mkdirSync(join(dir, 'scripts'), { recursive: true })
+      mkdirSync(join(dir, 'src/app'), { recursive: true })
+      mkdirSync(join(dir, 'src/lib'), { recursive: true })
+      mkdirSync(join(dir, 'public/.well-known'), { recursive: true })
+      cpSync(join(root, 'scripts/check-drift.mjs'), join(dir, 'scripts/check-drift.mjs'))
+      cpSync(join(root, 'src/lib/site.config.ts'), join(dir, 'src/lib/site.config.ts'))
+      cpSync(join(root, 'public/security.txt'), join(dir, 'public/security.txt'))
+      cpSync(
+        join(root, 'public/.well-known/security.txt'),
+        join(dir, 'public/.well-known/security.txt')
+      )
+      writeFileSync(join(dir, 'src/app/layout.tsx'), layoutSource(true))
+      writeFileSync(
+        join(dir, 'public/_headers'),
+        `/*\n  Content-Security-Policy: ${CSP} https://widget.example\n`
+      )
+
+      const { code, output } = runScript(join(dir, 'scripts/check-drift.mjs'))
+
+      expect(output).toContain('drifted between public/_headers and src/app/layout.tsx')
+      expect(output).toContain('https://widget.example')
+      expect(code).toBe(1)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/__tests__/scripts/check-drift-csp.test.ts
+++ b/__tests__/scripts/check-drift-csp.test.ts
@@ -110,6 +110,44 @@ describe('check-drift CSP: the inert file never masks the live control', () => {
   })
 })
 
+describe('check-drift CSP: unreadable is not the same as absent', () => {
+  // The warning severity above is correct only for a file that is genuinely
+  // absent. A file that exists but cannot be read (permissions, EISDIR, I/O)
+  // is a different fact, and collapsing the two would both misdiagnose it
+  // ("restore the file" — it is already there) and let the run pass, because
+  // the absent case is only a warning.
+  function runWithUnreadableHeaders(): { code: number; output: string } {
+    const dir = mkdtempSync(join(tmpdir(), 'ffc-drift-unreadable-'))
+    try {
+      mkdirSync(join(dir, 'scripts'), { recursive: true })
+      mkdirSync(join(dir, 'src/app'), { recursive: true })
+      mkdirSync(join(dir, 'src/lib'), { recursive: true })
+      mkdirSync(join(dir, 'public/.well-known'), { recursive: true })
+      cpSync(join(root, 'scripts/check-drift.mjs'), join(dir, 'scripts/check-drift.mjs'))
+      cpSync(join(root, 'src/lib/site.config.ts'), join(dir, 'src/lib/site.config.ts'))
+      cpSync(join(root, 'public/security.txt'), join(dir, 'public/security.txt'))
+      cpSync(
+        join(root, 'public/.well-known/security.txt'),
+        join(dir, 'public/.well-known/security.txt')
+      )
+      writeFileSync(join(dir, 'src/app/layout.tsx'), layoutSource(true))
+      // A directory where the file should be: readFile gives EISDIR, which is
+      // portable and needs no chmod (root ignores permission bits in CI).
+      mkdirSync(join(dir, 'public/_headers'))
+      return runScript(join(dir, 'scripts/check-drift.mjs'))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+
+  it('errors, and does not report it as missing', () => {
+    const { code, output } = runWithUnreadableHeaders()
+    expect(output).toContain('Could not read public/_headers')
+    expect(output).not.toContain('public/_headers is missing')
+    expect(code).toBe(1)
+  })
+})
+
 describe('check-drift CSP: _headers findings are warnings, not coverage', () => {
   it('warns rather than errors when public/_headers is missing', () => {
     const { code, output } = run('absent', true)

--- a/__tests__/scripts/check-drift-csp.test.ts
+++ b/__tests__/scripts/check-drift-csp.test.ts
@@ -116,7 +116,7 @@ describe('check-drift CSP: unreadable is not the same as absent', () => {
   // is a different fact, and collapsing the two would both misdiagnose it
   // ("restore the file" — it is already there) and let the run pass, because
   // the absent case is only a warning.
-  function runWithUnreadableHeaders(): { code: number; output: string } {
+  function runWithUnreadableHeaders(layoutMeta = true): { code: number; output: string } {
     const dir = mkdtempSync(join(tmpdir(), 'ffc-drift-unreadable-'))
     try {
       mkdirSync(join(dir, 'scripts'), { recursive: true })
@@ -130,7 +130,7 @@ describe('check-drift CSP: unreadable is not the same as absent', () => {
         join(root, 'public/.well-known/security.txt'),
         join(dir, 'public/.well-known/security.txt')
       )
-      writeFileSync(join(dir, 'src/app/layout.tsx'), layoutSource(true))
+      writeFileSync(join(dir, 'src/app/layout.tsx'), layoutSource(layoutMeta))
       // A directory where the file should be: readFile gives EISDIR, which is
       // portable and needs no chmod (root ignores permission bits in CI).
       mkdirSync(join(dir, 'public/_headers'))
@@ -144,6 +144,21 @@ describe('check-drift CSP: unreadable is not the same as absent', () => {
     const { code, output } = runWithUnreadableHeaders()
     expect(output).toContain('Could not read public/_headers')
     expect(output).not.toContain('public/_headers is missing')
+    expect(code).toBe(1)
+  })
+
+  // Unreadable is the fourth state _headers can be in, and it must obey the
+  // same rule as the other three: never end the check before the layout CSP has
+  // been assessed. The run fails either way, so the cost here is not a silent
+  // pass — it is a reader who fixes the read error, re-runs, and only then
+  // learns their site has no CSP. One finding at a time is the failure mode
+  // this function was rewritten to remove.
+  it('still reports the missing live CSP alongside the read error', () => {
+    const { code, output } = runWithUnreadableHeaders(false)
+    expect(output).toContain('Could not read public/_headers')
+    expect(output).toContain(
+      'src/app/layout.tsx has no <meta http-equiv="Content-Security-Policy">'
+    )
     expect(code).toBe(1)
   })
 })

--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,20 @@
-# Security and caching headers for Cloudflare Pages / Netlify-compatible hosts.
-# GitHub Pages does NOT read this file; CSP meta tag in <head> covers that case.
-# Keep in sync with the meta http-equiv tag in src/app/layout.tsx.
+# INERT ON FFC DEPLOYS — kept only for forward-compatibility. Read this first.
+#
+# This is a Cloudflare Pages / Netlify *build* feature. FFC sites are a GitHub
+# Pages origin behind the Cloudflare *proxy*, and neither of those reads this
+# file, so NOTHING below is served today. Measured on the wire, not assumed:
+# FreeForCharity/FFC-Cloudflare-Automation#884.
+#
+# What is actually served: the CSP meta http-equiv tag in src/app/layout.tsx —
+# and only CSP. The other five headers here (HSTS, X-Frame-Options,
+# X-Content-Type-Options, Referrer-Policy, Permissions-Policy) cannot be set
+# from a static export at all; <meta http-equiv> is ignored for them. They need
+# a response-header rule on the Cloudflare zone. Fleet posture is tracked in
+# FFC-Cloudflare-Automation#894.
+#
+# So: do not count this file as security coverage, and do not treat editing it
+# as remediating a header gap. Keep its CSP in sync with the layout.tsx meta
+# tag so a future move to Cloudflare Pages inherits a correct policy.
 #
 # CSP rationale:
 # - 'unsafe-inline' on script/style is required for Next.js inline runtime

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -349,11 +349,25 @@ function extractCspDirectives(policy) {
   return out
 }
 
+// Returned when a file exists but could not be read. Distinct from null
+// ("absent"), because the two call for opposite responses: absent means restore
+// it, unreadable means the file is already there and something else is wrong.
+// Collapsing them tells the reader to restore a file they already have — and
+// since the _headers finding is only a warning, it would let the run pass on a
+// filesystem error.
+const UNREADABLE = Symbol('unreadable')
+
 async function readIfExists(path) {
   try {
     return await readFile(path, 'utf8')
-  } catch {
-    return null
+  } catch (err) {
+    if (err.code === 'ENOENT') return null
+    errors.push(
+      `Could not read ${relative(ROOT, path)} (${err.code || err.message}). ` +
+        `The file is present but unreadable — this is not the same as it being absent, ` +
+        `so fix the read error rather than restoring the file from the template.`
+    )
+    return UNREADABLE
   }
 }
 
@@ -366,6 +380,10 @@ async function checkCspSync() {
   // reported only "public/_headers is missing".
   const headersBody = await readIfExists(join(ROOT, 'public', '_headers'))
   const layoutBody = await readIfExists(join(ROOT, 'src', 'app', 'layout.tsx'))
+
+  // readIfExists has already recorded the read failure as an error. Asserting
+  // on a file we could not read would only add a wrong diagnosis on top.
+  if (headersBody === UNREADABLE || layoutBody === UNREADABLE) return
 
   if (!headersBody) {
     warnings.push(

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -369,9 +369,10 @@ async function checkCspSync() {
 
   if (!headersBody) {
     warnings.push(
-      'public/_headers is missing. It is inert on FFC deploys (GitHub Pages origin behind the ' +
-        'Cloudflare proxy reads neither), so nothing is served differently today — restore it ' +
-        'from the template only to stay forward-compatible with a Cloudflare Pages deploy.'
+      'public/_headers is missing. Neither GitHub Pages nor the Cloudflare proxy in front of it ' +
+        'reads this file, so it is inert on FFC deploys and nothing is served differently ' +
+        'today — restore it from the template only to stay forward-compatible with a Cloudflare ' +
+        'Pages deploy.'
     )
   }
   if (!layoutBody) {

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -297,6 +297,26 @@ async function checkSiteConfigExists() {
   }
 }
 
+// What actually protects an FFC site, and what only looks like it does:
+//
+//   public/_headers is INERT on the stack FFC deploys. It is a Cloudflare
+//   Pages / Netlify *build* feature; FFC sites are a GitHub Pages origin
+//   behind the Cloudflare *proxy*, and neither of those reads the file.
+//   Measured on the wire, not inferred: FFC-Cloudflare-Automation#884.
+//   It is kept for forward-compatibility with a future Cloudflare Pages
+//   deploy, so its CSP is still worth keeping in sync — but its presence is
+//   not coverage, which is why its findings below are warnings, not errors.
+//
+//   The <meta http-equiv="Content-Security-Policy"> tag in layout.tsx is the
+//   only security header an FFC site actually serves today. Its absence is an
+//   error, and no finding about the inert file may mask it.
+//
+//   The other five headers (HSTS, X-Frame-Options, X-Content-Type-Options,
+//   Referrer-Policy, Permissions-Policy) cannot be set from a static export at
+//   all — <meta http-equiv> is ignored for them. They need a response-header
+//   mechanism on the zone (Cloudflare Transform Rule); fleet posture is
+//   measured by FFC-Cloudflare-Automation#894.
+//
 // CSP directives that are honored in <meta http-equiv> AND in HTTP headers.
 // We diff each of these between public/_headers and src/app/layout.tsx so
 // the two stay in lockstep on third-party origins.
@@ -329,24 +349,39 @@ function extractCspDirectives(policy) {
   return out
 }
 
+async function readIfExists(path) {
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
 async function checkCspSync() {
-  let headersBody, layoutBody
-  try {
-    headersBody = await readFile(join(ROOT, 'public', '_headers'), 'utf8')
-  } catch {
-    errors.push(
-      'public/_headers is missing. CSP and other security headers will not be served on ' +
-        'Cloudflare/Netlify deploys. Restore the file from the template.'
+  // Read both surfaces up front and report on each independently. Returning
+  // early on a finding about the inert _headers file would suppress the finding
+  // about the layout CSP meta tag — the only control that is actually served —
+  // so a site with no CSP at all would be told only about a file that does
+  // nothing. Measured against the shipped code before this fix: deleting BOTH
+  // reported only "public/_headers is missing".
+  const headersBody = await readIfExists(join(ROOT, 'public', '_headers'))
+  const layoutBody = await readIfExists(join(ROOT, 'src', 'app', 'layout.tsx'))
+
+  if (!headersBody) {
+    warnings.push(
+      'public/_headers is missing. It is inert on FFC deploys (GitHub Pages origin behind the ' +
+        'Cloudflare proxy reads neither), so nothing is served differently today — restore it ' +
+        'from the template only to stay forward-compatible with a Cloudflare Pages deploy.'
     )
-    return
   }
-  try {
-    layoutBody = await readFile(join(ROOT, 'src', 'app', 'layout.tsx'), 'utf8')
-  } catch {
+  if (!layoutBody) {
     errors.push('src/app/layout.tsx is missing. Restore the file from the template.')
-    return
+    return // nothing left to assert: the live CSP lives in this file
   }
-  const headersMatch = headersBody.match(/Content-Security-Policy:\s*([^\n]+)/)
+  // A null here means the inert file is absent — already warned about above.
+  // The layout check below still runs, because whether the live CSP exists is
+  // independent of that file.
+  const headersMatch = headersBody ? headersBody.match(/Content-Security-Policy:\s*([^\n]+)/) : null
   // Tolerate single or double quotes around the content attribute and
   // multi-line JSX formatting. The CSP itself contains nested quotes
   // (e.g. 'self', 'unsafe-inline') so we match the OUTER delimiter
@@ -355,20 +390,21 @@ async function checkCspSync() {
     layoutBody.match(/httpEquiv=["']Content-Security-Policy["'][\s\S]*?content="([^"]+)"/) ||
     layoutBody.match(/httpEquiv=["']Content-Security-Policy["'][\s\S]*?content='([^']+)'/) ||
     layoutBody.match(/httpEquiv=["']Content-Security-Policy["'][\s\S]*?content=\{`([^`]+)`\}/)
-  if (!headersMatch) {
-    errors.push(
-      'public/_headers has no Content-Security-Policy directive. Add one to keep the site ' +
-        'protected on Cloudflare/Netlify deploys.'
+  if (headersBody && !headersMatch) {
+    warnings.push(
+      'public/_headers has no Content-Security-Policy directive. This changes nothing that is ' +
+        'served today (the file is inert on FFC deploys); add one to keep the forward-compatible ' +
+        'copy aligned with the layout.tsx meta tag.'
     )
-    return
   }
   if (!layoutMatch) {
     errors.push(
-      'src/app/layout.tsx has no <meta http-equiv="Content-Security-Policy"> tag. Add one so ' +
-        'GitHub Pages deploys still get baseline CSP protection.'
+      'src/app/layout.tsx has no <meta http-equiv="Content-Security-Policy"> tag. This is the ' +
+        'ONLY security header an FFC site actually serves — without it the site has no CSP at ' +
+        'all, whatever public/_headers contains.'
     )
-    return
   }
+  if (!headersMatch || !layoutMatch) return
 
   const headersCsp = extractCspDirectives(headersMatch[1])
   const layoutCsp = extractCspDirectives(layoutMatch[1])

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -421,7 +421,9 @@ async function checkCspSync() {
       if (onlyInLayout.length) detail.push(`only in layout.tsx: ${onlyInLayout.join(' ')}`)
       errors.push(
         `CSP "${directive}" drifted between public/_headers and src/app/layout.tsx — ${detail.join(' / ')}. ` +
-          `Resource will load on one host and fail on the other. Update both files together.`
+          `The layout.tsx tag alone decides what loads today; _headers is the forward-compatible ` +
+          `copy. A drift means one was edited and the other was not, so whichever is behind is ` +
+          `wrong — check which, then update both files together.`
       )
     }
   }

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -366,8 +366,13 @@ async function readIfExists(path) {
     return await readFile(path, 'utf8')
   } catch (err) {
     if (err.code === 'ENOENT') return null
+    // Normalise to forward slashes. `relative()` returns platform separators,
+    // so on Windows this message alone would spell the file `public\_headers`
+    // while every hard-coded mention in this script — and in the tests — uses a
+    // forward slash. One run would name one file two ways.
+    const rel = relative(ROOT, path).split(sep).join('/')
     errors.push(
-      `Could not read ${relative(ROOT, path)} (${err.code || err.message}). ` +
+      `Could not read ${rel} (${err.code || err.message}). ` +
         `The file is present but unreadable — this is not the same as it being absent, ` +
         `so fix the read error rather than restoring the file from the template.`
     )

--- a/scripts/check-drift.mjs
+++ b/scripts/check-drift.mjs
@@ -378,14 +378,27 @@ async function checkCspSync() {
   // so a site with no CSP at all would be told only about a file that does
   // nothing. Measured against the shipped code before this fix: deleting BOTH
   // reported only "public/_headers is missing".
-  const headersBody = await readIfExists(join(ROOT, 'public', '_headers'))
-  const layoutBody = await readIfExists(join(ROOT, 'src', 'app', 'layout.tsx'))
+  const headersRaw = await readIfExists(join(ROOT, 'public', '_headers'))
+  const layoutRaw = await readIfExists(join(ROOT, 'src', 'app', 'layout.tsx'))
 
-  // readIfExists has already recorded the read failure as an error. Asserting
-  // on a file we could not read would only add a wrong diagnosis on top.
-  if (headersBody === UNREADABLE || layoutBody === UNREADABLE) return
+  // Only layout.tsx can end the check early, because the live CSP lives in it
+  // and there is nothing left to assert without it. An unreadable _headers must
+  // NOT end it: readIfExists has already recorded that read failure as its own
+  // error, and stopping here would suppress the layout finding — the same
+  // masking bug this function was rewritten to remove, wearing a fourth costume.
+  if (layoutRaw === UNREADABLE) return // error already recorded by readIfExists
+  if (!layoutRaw) {
+    errors.push('src/app/layout.tsx is missing. Restore the file from the template.')
+    return
+  }
+  const layoutBody = layoutRaw
 
-  if (!headersBody) {
+  // Unreadable and absent are both "no forward-compatible copy to compare
+  // against", but only absent earns the warning — an unreadable file is already
+  // reported with its real cause, and calling it missing would be a wrong
+  // diagnosis on top of a correct one.
+  const headersBody = headersRaw === UNREADABLE ? null : headersRaw
+  if (headersRaw !== UNREADABLE && !headersBody) {
     warnings.push(
       'public/_headers is missing. Neither GitHub Pages nor the Cloudflare proxy in front of it ' +
         'reads this file, so it is inert on FFC deploys and nothing is served differently ' +
@@ -393,13 +406,6 @@ async function checkCspSync() {
         'Pages deploy.'
     )
   }
-  if (!layoutBody) {
-    errors.push('src/app/layout.tsx is missing. Restore the file from the template.')
-    return // nothing left to assert: the live CSP lives in this file
-  }
-  // A null here means the inert file is absent — already warned about above.
-  // The layout check below still runs, because whether the live CSP exists is
-  // independent of that file.
   const headersMatch = headersBody ? headersBody.match(/Content-Security-Policy:\s*([^\n]+)/) : null
   // Tolerate single or double quotes around the content attribute and
   // multi-line JSX formatting. The CSP itself contains nested quotes


### PR DESCRIPTION
## Description

`public/_headers` is a Cloudflare Pages / Netlify **build** feature. FFC sites are a GitHub Pages origin behind the Cloudflare **proxy**, and neither reads the file — measured on the wire in [FFC-Cloudflare-Automation#884](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/884). The drift guard nonetheless treated it as the primary security control, and **returned early on any finding about it**.

The consequence is the one this guard exists to prevent. A site with **no CSP at all** was told only that an inert file was missing — and, because the layout check never ran, the finding that mattered was never printed.

### Measured, against the shipped script

Does the run report a missing `layout.tsx` CSP meta tag — the only security header an FFC site actually serves?

| `public/_headers` state | before | after |
| --- | --- | --- |
| absent | ❌ not reported | ✅ reported |
| present, no CSP line | ❌ not reported | ✅ reported |
| present, with CSP | ✅ reported | ✅ reported |
| **present but unreadable** (EISDIR / permissions) | ❌ reported as "missing", run **passed** | ✅ reported with its real cause, run fails |

That fourth row did not exist when this PR opened — `readIfExists` introduced it, and review caught that the matrix had gone stale. See *Review history* below.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test addition/update

## Related Issue(s)

Refs [FFC-Cloudflare-Automation#894](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/894) · Refs [FFC-Cloudflare-Automation#884](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/884)

Implements the follow-up #884's closing comment named as the one remaining piece a sandbox run could take unassisted: _"Correct `ffc-templating` and the templates' `check-drift.mjs`, whose error text still reads 'public/_headers is missing. CSP and other security headers will not be served'."_

## Changes Made

- **`scripts/check-drift.mjs`** — `checkCspSync` reports on both surfaces independently. **Only `layout.tsx` can end the check early**; no `_headers` state can suppress the live-CSP finding.
- **Severity now matches reality.** `_headers` findings are **warnings** (the file is inert; its absence changes nothing that is served, so it must not read as coverage). A missing layout CSP meta tag is an **error**.
- **`ENOENT` alone means absent.** Any other read failure reports its real cause and fails the run, rather than being misreported as a missing file — which would send the reader to restore a file that is already there.
- **The CSP drift error** no longer claims "Resource will load on one host and fail on the other". There is no such split; it now says what a drift actually means (one copy was edited, the other was not).
- **`public/_headers`** — header comment leads with `INERT ON FFC DEPLOYS` and names what is actually served.
- **`TEMPLATE_CUSTOMIZATION.md`** — the security-surface table no longer presents the two CSPs as peers. Removes the false claim that a missing origin means _"the resource will load on Cloudflare-hosted sites but fail on GitHub Pages."_
- **`README.md`** — one clarifying line in the widget-escalation bullet.
- **`__tests__/scripts/check-drift-csp.test.ts`** — 12 fixture tests over all four `_headers` states.

**The CSP sync check is unchanged and still an error.** Keeping the two copies in lockstep remains worth doing so a future move to Cloudflare Pages inherits a correct policy — the change is that the file is no longer counted as protection today.

### A note on the severity downgrade

This is not a weakened check. Before, the guard failed on a file that does nothing and could stay silent about a site with no CSP. After, it fails on the control that is actually served in every case. Net: strictly more real coverage, and no false coverage.

## Testing Performed

### Automated Testing

- [x] `npm run lint` — clean
- [x] `npm test` — **42 suites, 193 tests pass**
- [x] `npm run build` — static export succeeds
- [x] `npm run check:drift` — no drift on this repo
- [ ] `npm run test:e2e` — not run in this sandbox; no runtime code changed, only a dev-time script and prose

**Mutation-tested at each round** against the pre-fix script, so the assertions are load-bearing rather than decorative.

### Accessibility

- [x] N/A — no rendered output changed

## Documentation

- [x] Code is self-documenting or includes comments where needed
- [x] README.md updated
- [x] Other documentation updated (`TEMPLATE_CUSTOMIZATION.md`, `public/_headers`)

## Breaking Changes

None / N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix works
- [x] New and existing tests pass locally
- [x] I have updated the documentation accordingly
- [x] My commits follow the conventional commit format
- [x] Branch is current with `main`

## Review history — four rounds, and what they say about this diff

Recording it because the pattern is more useful than the individual fixes, and because **three of the four findings were defects I introduced while fixing the previous one.**

| # | Finding | Whose |
| --- | --- | --- |
| 1 | "Cloudflare proxy reads neither" left its referents implicit | pre-existing wording of mine |
| 2 | The CSP-drift error still asserted an on-the-wire split between the two copies | stale claim I walked past |
| 3 | `readIfExists` swallowed **all** read errors as "missing" — and my severity downgrade turned that from a failing error into a **passing warning** | armed by my change |
| 4 | The round-3 sentinel returned early, so an unreadable `_headers` suppressed the layout CSP finding — **the original masking bug, reintroduced by its own fix** | introduced by my change |

Two lessons worth carrying past this PR:

- **Lowering a severity is a change to every guard that relied on that error to halt the run.** One downgrade armed findings 3 and 4, neither visible in the diff of the downgrade itself.
- **The fix for a masking bug is a prime site for a new masking bug.** Findings 1-and-4 are structurally identical, three rounds apart, the second written two comments after I restated the invariant in prose. Prose in a review does not constrain code; the matrix over all four states does.

Draft, per the standing rule that @clarkemoyer reviews agent-authored changes.

**`FFC-EX-canary` carries a byte-identical pre-fix `scripts/check-drift.mjs` and `public/_headers`** (verified with `diff`). Not touched here — it should receive this through the normal template-sync path, and it is worth watching as the canary for whether that path works.

The companion change for `FFC-IN-Footer_Only_Template` is [#124](https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template/pull/124).