### PR TITLE
feat(smoke): probe www over HTTPS instead of only naming it in an error hint

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -102,19 +102,69 @@ jobs:
           # min and HTTPS returns 000 (TLS handshake fail) during that
           # window. Retry every 30s for up to 20 min before declaring a
           # real deployment failure.
-          deadline=$(( $(date +%s) + 1200 ))
-          attempt=0
-          status="000"
-          while [ "$(date +%s)" -lt "$deadline" ]; do
-            attempt=$(( attempt + 1 ))
-            status=$(curl -sI --max-time 15 -L "$URL" -o /dev/null -w "%{http_code}" 2>&1 || echo "000")
-            if [ "$status" = "200" ]; then
-              echo "Attempt $attempt: HTTP $status (cert provisioned, site reachable)"
-              break
-            fi
-            echo "Attempt $attempt: HTTP $status — waiting 30s (cert may still be provisioning)"
-            sleep 30
-          done
+          #
+          # The retry lives in $RUNNER_TEMP so the www probe below runs this
+          # exact loop rather than a second copy of it. A hand-rolled second
+          # loop flakes on the failure mode where www resolves correctly and
+          # only TLS fails, which is the one this file most needs to report.
+          cat > "$RUNNER_TEMP/probe-https.sh" <<'PROBE_LIB'
+          PROBE_HEADERS="${RUNNER_TEMP}/probe-headers.txt"
+
+          # curl exit codes meaning the TLS handshake itself failed — the shape
+          # a Pages certificate that is still being issued takes.
+          probe_is_tls_failure() {
+            case "$1" in
+              35 | 51 | 58 | 59 | 60 | 77 | 83) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          # probe_https <url> <budget_seconds> [retry_on: all|tls]
+          #   Retries every 30s until HTTP 200 (after redirects) or the budget
+          #   runs out.
+          #     all — wait through any non-200. During a cutover both DNS
+          #           propagation and cert issuance are legitimately slow.
+          #     tls — stop early on a settled answer (a 5xx, or a name that
+          #           does not resolve). Twenty minutes will not change either,
+          #           and the daily schedule re-probes anyway.
+          #   Sets PROBE_STATUS, PROBE_CURL_RC, PROBE_ATTEMPTS,
+          #   PROBE_URL_EFFECTIVE; last response headers land in $PROBE_HEADERS.
+          probe_https() {
+            url="$1"
+            budget="$2"
+            retry_on="${3:-all}"
+            deadline=$(( $(date +%s) + budget ))
+            PROBE_ATTEMPTS=0
+            while :; do
+              PROBE_ATTEMPTS=$(( PROBE_ATTEMPTS + 1 ))
+              probe_out=$(curl -sI --max-time 15 -L "$url" -D "$PROBE_HEADERS" -o /dev/null -w '%{http_code} %{url_effective}' 2>/dev/null)
+              PROBE_CURL_RC=$?
+              PROBE_STATUS="${probe_out%% *}"
+              PROBE_URL_EFFECTIVE="${probe_out##* }"
+              [ -n "$PROBE_STATUS" ] || PROBE_STATUS="000"
+              if [ "$PROBE_STATUS" = "200" ]; then
+                echo "Attempt $PROBE_ATTEMPTS: HTTP 200 (cert provisioned, reachable) — $url"
+                return 0
+              fi
+              if [ "$retry_on" = "tls" ] && ! probe_is_tls_failure "$PROBE_CURL_RC"; then
+                echo "Attempt $PROBE_ATTEMPTS: HTTP $PROBE_STATUS (curl exit $PROBE_CURL_RC) — settled answer, not retrying"
+                return 1
+              fi
+              if [ "$(date +%s)" -ge "$deadline" ]; then
+                echo "Attempt $PROBE_ATTEMPTS: HTTP $PROBE_STATUS (curl exit $PROBE_CURL_RC) — retry budget exhausted"
+                return 1
+              fi
+              echo "Attempt $PROBE_ATTEMPTS: HTTP $PROBE_STATUS (curl exit $PROBE_CURL_RC) — waiting 30s (cert may still be provisioning)"
+              sleep 30
+            done
+          }
+          PROBE_LIB
+          # shellcheck source=/dev/null
+          . "$RUNNER_TEMP/probe-https.sh"
+
+          probe_https "$URL" 1200 all || true
+          status="$PROBE_STATUS"
+          attempt="$PROBE_ATTEMPTS"
 
           echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "attempts=$attempt" >> "$GITHUB_OUTPUT"
@@ -128,6 +178,132 @@ jobs:
           # Save body for next step (curl-based content checks)
           curl -s --max-time 30 -L "$URL" > /tmp/page.html
           echo "Body length: $(wc -c < /tmp/page.html) bytes"
+
+      - name: Probe www over HTTPS (a redirect to the apex is a pass)
+        # Until now "www" appeared in this file exactly once, inside an
+        # ::error:: hint string — the engine told you to check www when
+        # something else failed and never probed it. A fleet sweep found 13 of
+        # 55 live sites broken on www while every smoke run was green.
+        #
+        # This is an HTTPS probe and deliberately not a DNS assertion: a www
+        # CNAME can point at GitHub Pages correctly and still fail TLS, because
+        # Pages issues a certificate only for the host named in public/CNAME.
+        # A DNS-level check passes that site while real visitors get a
+        # handshake error.
+        id: www
+        if: steps.url.outputs.mode == 'apex' && steps.url.outputs.skip != 'true'
+        env:
+          PAGES_CNAME: ${{ steps.url.outputs.pages_cname }}
+          REQUIRE_WWW: ${{ vars.SMOKE_REQUIRE_WWW }}
+        run: |
+          set -uo pipefail
+
+          # One-line verdict for the run summary, so the www result is visible
+          # without opening the log. Falls back to /dev/null so this script can
+          # be run outside Actions.
+          verdict() { echo "verdict=$1" >> "${GITHUB_OUTPUT:-/dev/null}"; }
+
+          # Defaults ON, matching the other SMOKE_* variables. A site whose www
+          # is known-broken opts itself out with SMOKE_REQUIRE_WWW=false until
+          # its DNS is fixed, instead of the fleet turning the check off.
+          case "$(printf '%s' "${REQUIRE_WWW:-true}" | tr '[:upper:]' '[:lower:]')" in
+            false | 0 | no | off)
+              echo "::notice::SMOKE_REQUIRE_WWW is off — www probe skipped for this repo"
+              verdict "skipped (SMOKE_REQUIRE_WWW off)"
+              exit 0
+              ;;
+          esac
+
+          # Ground truth is the Pages config resolved above, never re-derived.
+          if [ -z "$PAGES_CNAME" ]; then
+            echo "::notice::No Pages custom domain bound (manual URL dispatch) — no apex to derive www from; skipping"
+            verdict "skipped (no Pages custom domain)"
+            exit 0
+          fi
+          case "$PAGES_CNAME" in
+            www.*)
+              echo "::notice::Pages custom domain is '$PAGES_CNAME' — www is the canonical host and was probed above; skipping"
+              verdict "skipped (www is the canonical host)"
+              exit 0
+              ;;
+          esac
+
+          apex="$PAGES_CNAME"
+          www_host="www.${apex}"
+          www_url="https://${www_host}/"
+          echo "Probing $www_url (apex: https://${apex}/)"
+
+          # shellcheck source=/dev/null
+          . "$RUNNER_TEMP/probe-https.sh"
+          # 5 min rather than the apex's 20: the only retryable failure here is
+          # a www certificate still being issued right after someone bound www
+          # as the Pages host. Everything else is settled and returns at once,
+          # so the known-broken sites cost seconds, not a stalled job.
+          probe_https "$www_url" 300 tls || true
+
+          effective_host=$(printf '%s' "$PROBE_URL_EFFECTIVE" | sed -E 's#^[a-z]+://##; s#[:/].*$##')
+
+          case "$PROBE_STATUS" in
+            2??)
+              # -L already followed any redirect, so "3xx landing on the apex"
+              # arrives here as a 2xx whose effective host is the apex.
+              if [ "$effective_host" = "$apex" ]; then
+                echo "✓ www redirects to the apex and serves HTTP $PROBE_STATUS ($www_url -> $PROBE_URL_EFFECTIVE)"
+                verdict "OK — redirects to the apex"
+                exit 0
+              fi
+              if [ "$effective_host" = "$www_host" ]; then
+                echo "✓ www serves HTTP $PROBE_STATUS directly ($PROBE_URL_EFFECTIVE)"
+                verdict "OK — serves directly"
+                exit 0
+              fi
+              echo "::error::www is reachable but lands off-site: $www_url -> $PROBE_URL_EFFECTIVE"
+              echo "::error::Remediation: a visitor typing www reaches '${effective_host}', not '${apex}'. Point the www record at this site, or remove the off-site redirect."
+              verdict "FAILED — lands off-site at ${effective_host}"
+              exit 1
+              ;;
+          esac
+
+          # Classify the failure, because the three modes have three different
+          # fixes and a status code alone does not tell them apart. DNS is
+          # checked directly rather than inferred from curl's exit code, which
+          # varies with whatever resolver sits in front of the runner.
+          resolved=$(getent hosts "$www_host" 2>/dev/null | head -1 || true)
+
+          echo "::error::www is not reachable over HTTPS: $www_url (HTTP $PROBE_STATUS, curl exit $PROBE_CURL_RC, $PROBE_ATTEMPTS attempt(s))"
+
+          case "$PROBE_STATUS" in
+            5??)
+              # Any 5xx fails. The fleet shows both 526 and 500 for the same
+              # proxied-www defect, so a rule keyed on 526 misses half of them.
+              if grep -qiE '^(cf-ray:|server: *cloudflare)' "$PROBE_HEADERS" 2>/dev/null; then
+                echo "::error::Mode C — www is proxied by Cloudflare (cf-ray header present) and Cloudflare answered $PROBE_STATUS."
+                echo "::error::Remediation: set the www record to DNS-only (grey cloud) so it reaches GitHub Pages directly."
+                verdict "FAILED — mode C, proxied by Cloudflare (HTTP $PROBE_STATUS)"
+              else
+                echo "::error::Mode C — www answered $PROBE_STATUS from ${resolved:-an unidentified host}."
+                echo "::error::Remediation: whatever serves www is failing. Point it at GitHub Pages, or fix that origin."
+                verdict "FAILED — mode C, origin error (HTTP $PROBE_STATUS)"
+              fi
+              ;;
+            *)
+              if [ -z "$resolved" ]; then
+                echo "::error::Mode A — no www record: '$www_host' does not resolve."
+                echo "::error::Remediation: create a CNAME 'www' -> the Pages host, DNS-only (not proxied)."
+                verdict "FAILED — mode A, no www DNS record"
+              elif probe_is_tls_failure "$PROBE_CURL_RC"; then
+                echo "::error::Mode B — '$www_host' resolves (${resolved}) but the TLS handshake failed."
+                echo "::error::GitHub Pages issues a certificate only for the host in public/CNAME, so a correct www CNAME still has no certificate of its own."
+                echo "::error::Remediation: redirect www to the apex at the DNS/CDN layer, or bind www as the Pages custom domain and wait 5-15 min for the certificate."
+                verdict "FAILED — mode B, no certificate for www"
+              else
+                echo "::error::'$www_host' resolves (${resolved}) but the connection failed before any HTTP response (curl exit $PROBE_CURL_RC)."
+                echo "::error::Remediation: check that the www record points at GitHub Pages and that nothing in front of it is dropping the connection."
+                verdict "FAILED — connection error (curl exit $PROBE_CURL_RC)"
+              fi
+              ;;
+          esac
+          exit 1
 
       - name: Assert no FFC-template-default content
         # Template repos (FFC-IN-*Template*) legitimately serve the template
@@ -591,12 +767,14 @@ jobs:
           URL: ${{ steps.url.outputs.url }}
           STATUS: ${{ steps.probe.outputs.status }}
           ATTEMPTS: ${{ steps.probe.outputs.attempts }}
+          WWW_VERDICT: ${{ steps.www.outputs.verdict }}
         run: |
           {
             echo "## Post-Deploy Smoke Test"
             echo ""
             echo "- **URL:** $URL"
             echo "- **HTTPS status:** ${STATUS:-n/a} (probed in ${ATTEMPTS:-n/a} attempt(s))"
+            echo "- **www:** ${WWW_VERDICT:-not probed}"
             echo "- **Trigger:** ${{ github.event_name }} (schedule = daily uptime pass)"
             echo "- **Mode:** ${{ steps.url.outputs.mode }} (apex = custom-domain verification; default = pre-cutover deployment check)"
             echo "- **Job result:** ${{ job.status }}"

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -137,6 +137,11 @@ jobs:
             PROBE_ATTEMPTS=0
             while :; do
               PROBE_ATTEMPTS=$(( PROBE_ATTEMPTS + 1 ))
+              # Truncate explicitly. curl -D does this anyway, but both probes
+              # share this file, and a stale apex cf-ray surviving into the www
+              # probe would read as "mode C, proxied" on a TLS failure that
+              # never returned a header. Not worth depending on curl for.
+              : > "$PROBE_HEADERS"
               probe_out=$(curl -sI --max-time 15 -L "$url" -D "$PROBE_HEADERS" -o /dev/null -w '%{http_code} %{url_effective}' 2>/dev/null)
               PROBE_CURL_RC=$?
               PROBE_STATUS="${probe_out%% *}"
@@ -235,11 +240,21 @@ jobs:
 
           # shellcheck source=/dev/null
           . "$RUNNER_TEMP/probe-https.sh"
-          # 5 min rather than the apex's 20: the only retryable failure here is
-          # a www certificate still being issued right after someone bound www
-          # as the Pages host. Everything else is settled and returns at once,
-          # so the known-broken sites cost seconds, not a stalled job.
-          probe_https "$www_url" 300 tls || true
+
+          # Modes A and C settle in one attempt. Mode B does not, and cannot:
+          # a certificate that will never exist and one still being issued are
+          # the same TLS failure from out here. So the patience is only worth
+          # paying where issuance is actually plausible — just after a deploy
+          # or a manual cutover run. On the daily pass there is nothing to wait
+          # for, and a permanently-broken site would otherwise burn the whole
+          # budget every single day. One retry there, to ride out a transient
+          # handshake blip without turning a 5-minute stall into a daily cost.
+          if [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then
+            www_budget=30
+          else
+            www_budget=300
+          fi
+          probe_https "$www_url" "$www_budget" tls || true
 
           effective_host=$(printf '%s' "$PROBE_URL_EFFECTIVE" | sed -E 's#^[a-z]+://##; s#[:/].*$##')
 

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -315,10 +315,27 @@ jobs:
             verdict "skipped (no Pages custom domain)"
             exit 0
           fi
+          # `mode` is "apex" for ANY custom domain — it means "a domain is
+          # bound", not "that domain is a registrable apex". Every other step
+          # only ever probes the bound host, so the distinction never mattered
+          # before; this step is the first to DERIVE a new hostname from it,
+          # and a subdomain binding makes it derive one nobody intends.
+          #
+          # The general rule is "skip unless the cname is its registrable
+          # apex", but deciding that needs the Public Suffix List — a label
+          # count says lifelessonslearned.us.org is a subdomain when it is
+          # not. `staging.` is the shape the fleet actually has (10 repos as
+          # of 2026-08-05), so it is matched by name rather than guessed at
+          # structurally. Add sibling prefixes here if others appear.
           case "$PAGES_CNAME" in
             www.*)
               echo "::notice::Pages custom domain is '$PAGES_CNAME' — www is the canonical host and was probed above; skipping"
               verdict "skipped (www is the canonical host)"
+              exit 0
+              ;;
+            staging.*)
+              echo "::notice::Pages custom domain is '$PAGES_CNAME' — a pre-cutover staging host has no www of its own; skipping"
+              verdict "skipped (staging host)"
               exit 0
               ;;
           esac


### PR DESCRIPTION
## Description

`www` appeared in the canonical smoke engine **exactly once** — inside an `::error::` hint string at `post-deploy-smoke.yml:125`, telling you to check `www` when something _else_ failed. The engine never probed it. A fleet sweep found **13 of 55 live FFC-EX sites (24%) broken on `www`** while every smoke run stayed green.

This adds the probe. It changes no DNS: the remediations belong to #918 and are gated.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD or tooling change

## Related Issue(s)

Refs FreeForCharity/FFC-Cloudflare-Automation#934, child of FreeForCharity/FFC-Cloudflare-Automation#918

Not `Fixes`: #934 is tracked in the automation hub, and closing it wants the propagation note below settled too.

## Changes Made

- **New step `Probe www over HTTPS (a redirect to the apex is a pass)`**, immediately after the apex probe, `apex` mode only.
  - Resolves the apex from the **existing Pages-config ground truth** (`steps.url.outputs.pages_cname`), never re-derived.
  - Passes on **2xx**, or a redirect that lands on the apex — `curl -L` has already followed it, so that case arrives as a 2xx whose effective host is the apex. A 2xx that lands on a _third_ host fails, with the host named.
  - **Classifies the failure**, because the three modes have three different fixes: **A** no `www` record · **B** `www` → Pages but no certificate of its own · **C** `www` proxied by Cloudflare. **Any 5xx fails** — the fleet shows both 526 and 500 for the same proxied-`www` defect, so a rule keyed on 526 misses half of them.
  - Gated on **`SMOKE_REQUIRE_WWW`**, defaulting **on**, matching the existing `SMOKE_*` convention. The 13 known-broken sites opt out individually instead of the fleet losing the check.
- **The apex probe's retry loop moved to `$RUNNER_TEMP` and is sourced by both steps**, so there is one loop rather than two copies. Its retry policy became a parameter:
  - `all` (apex, 20 min, unchanged behaviour) — wait through any non-200; during a cutover both DNS propagation and cert issuance are legitimately slow.
  - `tls` (www) — retry only a TLS-layer failure. A settled 5xx or an unresolvable name will not change within any budget, so modes A and C return in one attempt. **Mode B cannot return early** — a certificate that will never exist and one still being issued are the same TLS failure from out here — so the budget is scaled by trigger: **300s on deploy and dispatch runs**, where issuance is actually plausible, and **30s on the daily schedule** (one retry, enough to ride out a transient handshake blip). Without that split a permanently-broken mode-B site burned the full budget every day, forever.
- **`www` verdict added to the run summary**, so the result is visible without opening the log.

### Two judgement calls worth a reviewer's eye

**1. It is an HTTPS probe, not a DNS assertion — deliberately.** `www.technologymonastery.org` has _correct_ DNS (`getent` resolves it to `freeforcharity.github.io`) and still fails TLS, because Pages issues a certificate only for the host named in `public/CNAME`. A DNS-level check passes that site while real visitors get a handshake error.

**2. Mode detection reads DNS directly rather than trusting curl's exit code.** The obvious implementation keys mode A on curl exit 6 ("couldn't resolve host"). Under the sandbox's egress proxy the same NXDOMAIN surfaces as **exit 56**, and a runner with a different resolver in front of it could differ again. `getent hosts` is checked explicitly, so classification does not depend on which resolver the runner happens to have. This is the difference between the guard naming the right remediation and naming a plausible wrong one.

## Testing Performed

### The four failure modes, against the real hosts

The step's script was extracted from the YAML and run against the live fleet. Not a fixture — these are the sites named in the acceptance criteria.

```
===== PAGES_CNAME='amargraves.org'                (healthy: www 301s to apex)
Attempt 1: HTTP 200 (cert provisioned, reachable) — https://www.amargraves.org/
✓ www redirects to the apex and serves HTTP 200 (https://www.amargraves.org/ -> https://amargraves.org/)
EXIT=0  ->  verdict=OK — redirects to the apex

===== PAGES_CNAME='aprilhansen.com'               (mode C, 526)
Attempt 1: HTTP 526 (curl exit 0) — settled answer, not retrying
::error::Mode C — www is proxied by Cloudflare (cf-ray header present) and Cloudflare answered 526.
::error::Remediation: set the www record to DNS-only (grey cloud) so it reaches GitHub Pages directly.
EXIT=1  ->  verdict=FAILED — mode C, proxied by Cloudflare (HTTP 526)

===== PAGES_CNAME='armstrongacesbaseball.org'     (mode C, 500 — same defect, different code)
Attempt 1: HTTP 500 (curl exit 0) — settled answer, not retrying
::error::Mode C — www is proxied by Cloudflare (cf-ray header present) and Cloudflare answered 500.
EXIT=1  ->  verdict=FAILED — mode C, proxied by Cloudflare (HTTP 500)

===== PAGES_CNAME='cvrs-us.org'                   (mode A, does not resolve)
Attempt 1: HTTP 000 (curl exit 56) — settled answer, not retrying
::error::Mode A — no www record: 'www.cvrs-us.org' does not resolve.
::error::Remediation: create a CNAME 'www' -> the Pages host, DNS-only (not proxied).
EXIT=1  ->  verdict=FAILED — mode A, no www DNS record

===== PAGES_CNAME='technologymonastery.org'       (mode B, correct DNS + TLS failure)
Attempt 1: HTTP 000 (curl exit 60) — waiting 30s (cert may still be provisioning)
   … 10 more attempts across the 5-minute budget …
Attempt 11: HTTP 000 (curl exit 60) — retry budget exhausted
::error::Mode B — 'www.technologymonastery.org' resolves (2606:50c0:8001::153 freeforcharity.github.io www.technologymonastery.org) but the TLS handshake failed.
::error::GitHub Pages issues a certificate only for the host in public/CNAME, so a correct www CNAME still has no certificate of its own.
::error::Remediation: redirect www to the apex at the DNS/CDN layer, or bind www as the Pages custom domain and wait 5-15 min for the certificate.
EXIT=1  ->  verdict=FAILED — mode B, no certificate for www
```

Note `cvrs-us.org` classified as mode A on **curl exit 56**, not 6 — the DNS check carried it, which is the point of judgement call 2.

The mode-B block above is the **deploy/dispatch** path at its full 300s. On the daily schedule the same host settles in 2 attempts / 32s with an identical verdict — see the trigger-scaled budget below.

### The gate and the skip paths

```
SMOKE_REQUIRE_WWW='false'      -> ::notice::SMOKE_REQUIRE_WWW is off — www probe skipped   EXIT=0
PAGES_CNAME=''                 -> ::notice::No Pages custom domain bound … skipping        EXIT=0
PAGES_CNAME='www.example.org'  -> ::notice::www is the canonical host … skipping           EXIT=0
```

### The retry parameter, both directions

The same host, the same budget, the two policies — proving `tls` does not merely inherit `all`:

```
probe_https https://www.aprilhansen.com/ 45 all   -> 3 attempts, kept waiting through the 526
probe_https https://www.aprilhansen.com/ 45 tls   -> 1 attempt,  "settled answer, not retrying"
```

### The trigger-scaled budget (added in `7c3c10b`, from review)

Budget selection, and the mode-B cost it exists to remove:

```
event='schedule'          -> budget=30      event='workflow_run'      -> budget=300
event='workflow_dispatch' -> budget=300     event=''                  -> budget=300

technologymonastery.org, GITHUB_EVENT_NAME=schedule:
  Attempt 1: HTTP 000 (curl exit 60) — waiting 30s (cert may still be provisioning)
  Attempt 2: HTTP 000 (curl exit 60) — retry budget exhausted
  elapsed=32s   verdict=FAILED — mode B, no certificate for www     (was ~5 min)

Re-measured on the same path, unchanged: mode C 0s, mode A 1s, healthy 0s — all 1 attempt.
```

And the header-isolation fix, tested in the order that would bite (Cloudflare probe first, TLS failure second):

```
after Cloudflare probe:   headers=430 bytes, cf-ray present? YES
after TLS-failure probe:  headers=39 bytes,  cf-ray present? no
```

The 39 bytes are this sandbox's egress proxy answering `CONNECT`; on a runner the dump is empty. Neither carries a `cf-ray`, so mode C cannot be inferred from a request that never received a header.

### Apex probe unchanged after the refactor

```
URL=https://amargraves.org/ -> Attempt 1: HTTP 200 … / Body length: 9906 bytes / status=200 attempts=1
```

### Automated Testing

- [x] `npm run lint` — clean (husky pre-commit ran `format:check`, `lint`, `check:drift`)
- [x] `npm test` — 41 suites, 181 tests, all pass
- [x] `npm run check:drift` — no drift
- [x] `prettier --check` — clean under both the repo's pinned 3.9.0 and 3.8.1
- [x] **actionlint 1.7.7 + shellcheck 0.11.0** — clean. Findings are byte-identical to `origin/main`'s baseline (one pre-existing `SC2129`, one pre-existing `SC2086`), so this change adds none.
- [ ] `npm run build` / `npm run test:e2e` — not run locally; the change is a workflow YAML with no bearing on the Next build. CI runs both.

**actionlint was verified to actually inspect this file** rather than passing vacuously: a mutation (`steps.url` → `steps.NOPE`) makes it exit 1 and point at line 196 of the new step.

## Documentation

- [x] Code is self-documenting — each non-obvious decision (why HTTPS not DNS, why any 5xx, why the budget is trigger-scaled, why `getent`) is commented at the point it applies
- [x] No separate docs to update: `SMOKE_*` variables are documented only in this file, and nothing else in the repo references the smoke engine

## Breaking Changes

None for this repo. **Two things a reviewer should decide on, though:**

1. **Sites with broken `www` will now go red.** That is the intent — they are broken today and silently green. If a staged rollout is wanted, set `SMOKE_REQUIRE_WWW=false` on the 13 affected repos _before_ propagation; the variable exists for exactly this. Confirmed by API during review: **none of the 13 currently has it set**, so the opt-out is real but unused.
2. **Workflow 738 enforces byte-identity of this file across the fleet**, so merging the canonical alone will make the drift audit report every FFC-EX repo as drifted (#893, already open). **Propagation is deliberately not in this PR**, per #934. It wants its own pass that copies the file to each FFC-EX repo and sets `SMOKE_REQUIRE_WWW=false` on the known-broken ones in the same sweep, so the fleet never sits in the red-and-drifted state between the two steps.

## Additional Notes

Draft on purpose: it adds a failing condition to the daily uptime pass for every site in the fleet, and the propagation sequencing above is a call for a human.

Per #934's verification note, a `success` conclusion would not have been sufficient evidence — so the step output is quoted above rather than summarised.

**Status:** review round 1 handled in `7c3c10b`; `main` merged in at `728219c`; all 10 checks green, no unresolved threads, `mergeable_state: clean`. This body was corrected on 2026-08-05 — it had described the pre-review 5-minute www budget, which is the same class of stale-prose error the review caught in the code comment.