### PR TITLE
fix(deps): clear the nanoid HIGH and postcss advisories (#440)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^16.2.11",
-        "postcss": "^8.5.22",
+        "postcss": "^8.5.26",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-icons": "^5.6.0",
@@ -3574,6 +3574,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.1",
@@ -12057,24 +12123,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -12828,9 +12876,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -12847,12 +12895,30 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "next": "^16.2.11",
-    "postcss": "^8.5.22",
+    "postcss": "^8.5.26",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-icons": "^5.6.0",
@@ -70,6 +70,7 @@
     "picomatch": ">=4.0.4",
     "tmp": "^0.2.6",
     "sharp": "^0.35.3",
+    "nanoid": "^3.3.18",
     "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
Closes #440.

Every site provisioned from this template inherited a failing production `npm audit`, so a brand-new charity repo showed a **red Security Audit before anyone touched it**. Found on `FFC-EX-mindfulmovesproject.org`, created 2026-08-15 by workflow 701 — first CI run, untouched repo, job red.

| Package   | Before | After  | Severity | Advisory |
| --------- | ------ | ------ | -------- | -------- |
| `nanoid`  | 3.3.16 | 3.3.18 | **HIGH** | GHSA-2v37-7h3g-55p8 |
| `postcss` | 8.5.22 | 8.5.26 | moderate | GHSA-fxqj-rqcc-2cmp |

## The change

Both arrive transitively through `next`. Fixed the way this repo **already** fixes transitive advisories — `overrides`, where `qs`, `uuid`, `picomatch`, `tmp` and `sharp` are already pinned:

- `dependencies.postcss` `^8.5.22` → `^8.5.26`. It's a direct dependency and the existing `"postcss": "$postcss"` override cascades it, so bumping the declared range is sufficient.
- `overrides.nanoid` `^3.3.18` added. `nanoid` is declared nowhere, so it needed a new entry.

Two files, `package.json` (3 lines) and `package-lock.json`.

## ⚠️ `npm audit fix` is the wrong remedy here, and its output does not say so

Worth reading before anyone "simplifies" this PR, because the obvious fix is a trap that reports success:

`npm audit fix` prints **"found 0 vulnerabilities"** and touches only the lockfile — but it resolves the advisory by taking **`next` 16.2.11 → 16.3.1**. That's legal inside the declared `^16.2.11` caret, so `package.json` looks untouched, and it **breaks the build with 93 TypeScript errors**: Next 16.3 changes type resolution such that jest-dom's global matcher augmentation stops applying to test files, so `toBeInTheDocument` / `toHaveAttribute` no longer exist on `Matchers`.

Measured rather than assumed — I ran the baseline before attributing the failure:

| tree | `npm run build` | TS errors |
| --- | --- | --- |
| `main`, unmodified | **rc=0** | **0** |
| `npm audit fix` applied | rc=1 | **93** |

A green audit beside a broken build is the failure mode to expect if this is re-run. **This PR holds `next` at 16.2.11.**

**Second trap, same area:** an override of `>=3.3.18` resolves `nanoid` to **6.0.1** — a major jump to an ESM-only package with breaking API changes, where `next` expects 3.x. Pinned `^3.3.18` so it stays on the 3.x line, which is where the fix actually shipped (npm dist-tag `legacy`).

Net lockfile effect: **9 entries move**, six of which are inert `@tailwindcss/oxide-wasm32-wasi` sub-dependency records.

## Verification

All on this branch after a clean `npm ci`:

| Check | Result |
| --- | --- |
| `npm audit --omit=dev --audit-level=high` *(security-audit.yml's exact command)* | **rc=0** — "found 0 vulnerabilities" |
| `npm run build` | **rc=0**, 0 TypeScript errors, static export produced |
| `npm test` | **rc=0** — 44/44 suites, 231/231 tests |
| `npm run check:drift` | **rc=0** — "Repo aligned with FFC best practices" |
| `npm run check:site-config` | **rc=0** |
| `npm run verify:build` | **rc=0** |

The pre-commit hook chain (prettier, eslint, `check:drift`) also passed on commit.

## Not done here, deliberately

**Existing `FFC-EX-*` repos do not inherit this retroactively.** They keep the advisory until re-provisioned or bumped individually. That's a fleet decision rather than something to assume silently — flagged on #440. `FFC-EX-mindfulmovesproject.org` is the one live instance today, and it's a brand-new repo with no work in it yet, so re-provisioning it is cheap if that's the preferred route.

Opened as a **draft**: this is the common ancestor of every FFC charity site, and the `next`-bump finding above is worth a human read before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPEKVUEL5L5dj9MZRerqDc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPEKVUEL5L5dj9MZRerqDc)_